### PR TITLE
Raise max money to 100M coins

### DIFF
--- a/src/consensus/amount.h
+++ b/src/consensus/amount.h
@@ -18,13 +18,13 @@ static constexpr CAmount COIN = 100000000;
 /** No amount larger than this (in satoshi) is valid.
  *
  * Note that this constant is *not* the total money supply, which in Bitcoin
- * currently happens to be less than 21,000,000 BTC for various reasons, but
+ * currently happens to be less than 100,000,000 BTC for various reasons, but
  * rather a sanity check. As this sanity check is used by consensus-critical
  * validation code, the exact value of the MAX_MONEY constant is consensus
  * critical; in unusual circumstances like a(nother) overflow bug that allowed
  * for the creation of coins out of thin air modification could lead to a fork.
  * */
-static constexpr CAmount MAX_MONEY = 21000000 * COIN;
+static constexpr CAmount MAX_MONEY = 100000000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 #endif // BITCOIN_CONSENSUS_AMOUNT_H

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -21,8 +21,8 @@
 // amounts 1 .. 10000
 #define NUM_MULTIPLES_1BTC 10000
 
-// amounts 50 .. 21000000
-#define NUM_MULTIPLES_50BTC 420000
+// amounts 50 .. 100000000
+#define NUM_MULTIPLES_50BTC 2000000
 
 BOOST_FIXTURE_TEST_SUITE(compress_tests, BasicTestingSetup)
 
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(compress_amounts)
     BOOST_CHECK(TestPair(         CENT,       0x7));
     BOOST_CHECK(TestPair(         COIN,       0x9));
     BOOST_CHECK(TestPair(      50*COIN,      0x32));
-    BOOST_CHECK(TestPair(21000000*COIN, 0x1406f40));
+    BOOST_CHECK(TestPair(100000000*COIN, 0x5f5e100));
 
     for (uint64_t i = 1; i <= NUM_MULTIPLES_UNIT; i++)
         BOOST_CHECK(TestEncode(i));

--- a/src/test/feefrac_tests.cpp
+++ b/src/test/feefrac_tests.cpp
@@ -127,24 +127,24 @@ BOOST_AUTO_TEST_CASE(feefrac_operators)
     FeeFrac busted{(static_cast<int64_t>(INT32_MAX)) + 1, INT32_MAX};
     BOOST_CHECK(!(busted < busted));
 
-    FeeFrac max_fee{2100000000000000, INT32_MAX};
+    FeeFrac max_fee{10000000000000000, INT32_MAX};
     BOOST_CHECK(!(max_fee < max_fee));
     BOOST_CHECK(!(max_fee > max_fee));
     BOOST_CHECK(max_fee <= max_fee);
     BOOST_CHECK(max_fee >= max_fee);
 
     BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(0), 0);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1), 977888);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(2), 1955777);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(3), 2933666);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1256796054), 1229006664189047);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(INT32_MAX), 2100000000000000);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1), 4656612);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(2), 9313225);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(3), 13969838);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1256796054), 5852412686614511);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(INT32_MAX), 10000000000000000);
     BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(0), 0);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1), 977889);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(2), 1955778);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(3), 2933667);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1256796054), 1229006664189048);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(INT32_MAX), 2100000000000000);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1), 4656613);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(2), 9313226);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(3), 13969839);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1256796054), 5852412686614512);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(INT32_MAX), 10000000000000000);
 
     FeeFrac max_fee2{1, 1};
     BOOST_CHECK(max_fee >= max_fee2);

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -212,8 +212,8 @@ struct DepGraphFormatter
                 // Read fee, encoded as an unsigned varint (odd=negative, even=non-negative).
                 uint64_t coded_fee;
                 s >> VARINT(coded_fee);
-                coded_fee &= 0xFFFFFFFFFFFFF; // Enough for fee between -21M...21M BTC.
-                static_assert(0xFFFFFFFFFFFFF > uint64_t{2} * 21000000 * 100000000);
+                coded_fee &= 0xFFFFFFFFFFFFFF; // Enough for fee between -100M...100M BTC.
+                static_assert(0xFFFFFFFFFFFFFF > uint64_t{2} * 100000000 * 100000000);
                 new_feerate = {UnsignedToSigned(coded_fee), size};
                 // Read dependency information.
                 auto topo_idx = reordering.size();

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -400,7 +400,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.log.info("Check a package that passes mempoolminfee but is evicted immediately after submission")
         mempoolmin_feerate = node.getmempoolinfo()["mempoolminfee"]
         current_mempool = node.getrawmempool(verbose=False)
-        worst_feerate_btcvb = Decimal("21000000")
+        worst_feerate_btcvb = Decimal("100000000")
         for txid in current_mempool:
             entry = node.getmempoolentry(txid)
             worst_feerate_btcvb = min(worst_feerate_btcvb, entry["fees"]["descendant"] / entry["descendantsize"])

--- a/test/functional/test_framework/compressor.py
+++ b/test/functional/test_framework/compressor.py
@@ -55,4 +55,4 @@ class TestFrameworkCompressor(unittest.TestCase):
         check_amount(1000000, 0x7)
         check_amount(COIN, 0x9)
         check_amount(50*COIN, 0x32)
-        check_amount(21000000*COIN, 0x1406f40)
+        check_amount(100000000*COIN, 0x5f5e100)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -39,7 +39,7 @@ MAX_BLOOM_FILTER_SIZE = 36000
 MAX_BLOOM_HASH_FUNCS = 50
 
 COIN = 100000000  # 1 btc in satoshis
-MAX_MONEY = 21000000 * COIN
+MAX_MONEY = 100000000 * COIN
 
 MAX_BIP125_RBF_SEQUENCE = 0xfffffffd  # Sequence number that is rbf-opt-in (BIP 125) and csv-opt-out (BIP 68)
 MAX_SEQUENCE_NONFINAL = 0xfffffffe  # Sequence number that is csv-opt-out (BIP 68)
@@ -684,7 +684,7 @@ class CTransaction:
 
     def is_valid(self):
         for tout in self.vout:
-            if tout.nValue < 0 or tout.nValue > 21000000 * COIN:
+            if tout.nValue < 0 or tout.nValue > MAX_MONEY:
                 return False
         return True
 


### PR DESCRIPTION
## Summary
- expand MAX_MONEY to 100,000,000 coins
- align tests and helpers with the new monetary cap
- refresh comments about total coin supply

## Testing
- `ninja test_bitcoin` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b153318f40832d821a97ed71c9914a