### PR TITLE
Adjust halving schedule to four years

### DIFF
--- a/doc/release-notes/halving-interval-update.md
+++ b/doc/release-notes/halving-interval-update.md
@@ -1,0 +1,4 @@
+# Halving interval adjustment
+
+- Changed `nSubsidyHalvingInterval` from 210,000 to 2,803,200 blocks to match a 45-second block target and four-year subsidy halving schedule.
+- Updated related constants, tests, and maximum money supply to 280,320,000 coins.

--- a/src/consensus/amount.h
+++ b/src/consensus/amount.h
@@ -17,14 +17,14 @@ static constexpr CAmount COIN = 100000000;
 
 /** No amount larger than this (in satoshi) is valid.
  *
- * Note that this constant is *not* the total money supply, which in Bitcoin
- * currently happens to be less than 21,000,000 BTC for various reasons, but
+ * Note that this constant is *not* the total money supply, which in Adonai
+ * currently happens to be less than 280,320,000 ADO for various reasons, but
  * rather a sanity check. As this sanity check is used by consensus-critical
  * validation code, the exact value of the MAX_MONEY constant is consensus
  * critical; in unusual circumstances like a(nother) overflow bug that allowed
  * for the creation of coins out of thin air modification could lead to a fork.
  * */
-static constexpr CAmount MAX_MONEY = 21000000 * COIN;
+static constexpr CAmount MAX_MONEY = 280320000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 #endif // BITCOIN_CONSENSUS_AMOUNT_H

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -139,7 +139,7 @@ public:
         m_chain_type = ChainType::MAIN;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 210000;
+        consensus.nSubsidyHalvingInterval = 2803200;
         consensus.script_flag_exceptions.clear();
 
         consensus.BIP34Height = 0;
@@ -284,7 +284,7 @@ public:
         m_chain_type = ChainType::TESTNET;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 210000;
+        consensus.nSubsidyHalvingInterval = 2803200;
         consensus.script_flag_exceptions.emplace( // BIP16 exception
             uint256{"00000000dd30457c001f4095d208cc1296b0eed002427aa599874af7a432b105"}, SCRIPT_VERIFY_NONE);
         consensus.BIP34Height = 21111;
@@ -376,7 +376,7 @@ public:
         m_chain_type = ChainType::TESTNET4;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 210000;
+        consensus.nSubsidyHalvingInterval = 2803200;
         consensus.BIP34Height = 1;
         consensus.BIP34Hash = uint256{};
         consensus.BIP65Height = 1;
@@ -495,7 +495,7 @@ public:
         consensus.signet_blocks = true;
         consensus.signet_challenge.assign(challenge_bin.begin(), challenge_bin.end());
 
-        consensus.nSubsidyHalvingInterval = 210000;
+        consensus.nSubsidyHalvingInterval = 2803200;
         consensus.BIP34Height = 1;
         consensus.BIP34Hash = uint256{};
         consensus.BIP65Height = 1;

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -21,8 +21,8 @@
 // amounts 1 .. 10000
 #define NUM_MULTIPLES_1BTC 10000
 
-// amounts 50 .. 21000000
-#define NUM_MULTIPLES_50BTC 420000
+// amounts 50 .. 280320000
+#define NUM_MULTIPLES_50BTC 5606400
 
 BOOST_FIXTURE_TEST_SUITE(compress_tests, BasicTestingSetup)
 
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(compress_amounts)
     BOOST_CHECK(TestPair(         CENT,       0x7));
     BOOST_CHECK(TestPair(         COIN,       0x9));
     BOOST_CHECK(TestPair(      50*COIN,      0x32));
-    BOOST_CHECK(TestPair(21000000*COIN, 0x1406f40));
+    BOOST_CHECK(TestPair(280320000*COIN, 0x10b55800));
 
     for (uint64_t i = 1; i <= NUM_MULTIPLES_UNIT; i++)
         BOOST_CHECK(TestEncode(i));

--- a/src/test/feefrac_tests.cpp
+++ b/src/test/feefrac_tests.cpp
@@ -127,24 +127,24 @@ BOOST_AUTO_TEST_CASE(feefrac_operators)
     FeeFrac busted{(static_cast<int64_t>(INT32_MAX)) + 1, INT32_MAX};
     BOOST_CHECK(!(busted < busted));
 
-    FeeFrac max_fee{2100000000000000, INT32_MAX};
+    FeeFrac max_fee{28032000000000000, INT32_MAX};
     BOOST_CHECK(!(max_fee < max_fee));
     BOOST_CHECK(!(max_fee > max_fee));
     BOOST_CHECK(max_fee <= max_fee);
     BOOST_CHECK(max_fee >= max_fee);
 
     BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(0), 0);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1), 977888);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(2), 1955777);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(3), 2933666);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1256796054), 1229006664189047);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(INT32_MAX), 2100000000000000);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1), 13053417);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(2), 26106834);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(3), 39160251);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1256796054), 16405483243117799);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(INT32_MAX), 28032000000000000);
     BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(0), 0);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1), 977889);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(2), 1955778);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(3), 2933667);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1256796054), 1229006664189048);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(INT32_MAX), 2100000000000000);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1), 13053418);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(2), 26106835);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(3), 39160252);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1256796054), 16405483243117800);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(INT32_MAX), 28032000000000000);
 
     FeeFrac max_fee2{1, 1};
     BOOST_CHECK(max_fee >= max_fee2);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -408,8 +408,8 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
 
         // subsidy changing
         int nHeight = m_node.chainman->ActiveChain().Height();
-        // Create an actual 209999-long block chain (without valid blocks).
-        while (m_node.chainman->ActiveChain().Tip()->nHeight < 209999) {
+        // Create an actual 2,803,199-long block chain (without valid blocks).
+        while (m_node.chainman->ActiveChain().Tip()->nHeight < 2803199) {
             CBlockIndex* prev = m_node.chainman->ActiveChain().Tip();
             CBlockIndex* next = new CBlockIndex();
             next->phashBlock = new uint256(m_rng.rand256());
@@ -420,8 +420,8 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
             m_node.chainman->ActiveChain().SetTip(*next);
         }
         BOOST_REQUIRE(mining->createNewBlock(options));
-        // Extend to a 210000-long block chain.
-        while (m_node.chainman->ActiveChain().Tip()->nHeight < 210000) {
+        // Extend to a 2,803,200-long block chain.
+        while (m_node.chainman->ActiveChain().Tip()->nHeight < 2803200) {
             CBlockIndex* prev = m_node.chainman->ActiveChain().Tip();
             CBlockIndex* next = new CBlockIndex();
             next->phashBlock = new uint256(m_rng.rand256());

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -212,8 +212,8 @@ struct DepGraphFormatter
                 // Read fee, encoded as an unsigned varint (odd=negative, even=non-negative).
                 uint64_t coded_fee;
                 s >> VARINT(coded_fee);
-                coded_fee &= 0xFFFFFFFFFFFFF; // Enough for fee between -21M...21M BTC.
-                static_assert(0xFFFFFFFFFFFFF > uint64_t{2} * 21000000 * 100000000);
+                coded_fee &= 0xFFFFFFFFFFFFF; // Enough for fee between -280M...280M ADO.
+                static_assert(0xFFFFFFFFFFFFF > uint64_t{2} * 280320000 * 100000000);
                 new_feerate = {UnsignedToSigned(coded_fee), size};
                 // Read dependency information.
                 auto topo_idx = reordering.size();

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
         nSum += nSubsidy * 1000;
         BOOST_CHECK(MoneyRange(nSum));
     }
-    BOOST_CHECK_EQUAL(nSum, CAmount{2099999997690000});
+    BOOST_CHECK_EQUAL(nSum, CAmount{27154062500000000});
 }
 
 BOOST_AUTO_TEST_CASE(signet_parse_tests)

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -400,7 +400,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.log.info("Check a package that passes mempoolminfee but is evicted immediately after submission")
         mempoolmin_feerate = node.getmempoolinfo()["mempoolminfee"]
         current_mempool = node.getrawmempool(verbose=False)
-        worst_feerate_btcvb = Decimal("21000000")
+        worst_feerate_btcvb = Decimal("280320000")
         for txid in current_mempool:
             entry = node.getmempoolentry(txid)
             worst_feerate_btcvb = min(worst_feerate_btcvb, entry["fees"]["descendant"] / entry["descendantsize"])

--- a/test/functional/test_framework/compressor.py
+++ b/test/functional/test_framework/compressor.py
@@ -55,4 +55,4 @@ class TestFrameworkCompressor(unittest.TestCase):
         check_amount(1000000, 0x7)
         check_amount(COIN, 0x9)
         check_amount(50*COIN, 0x32)
-        check_amount(21000000*COIN, 0x1406f40)
+        check_amount(280320000*COIN, 0x10b55800)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -39,7 +39,7 @@ MAX_BLOOM_FILTER_SIZE = 36000
 MAX_BLOOM_HASH_FUNCS = 50
 
 COIN = 100000000  # 1 btc in satoshis
-MAX_MONEY = 21000000 * COIN
+MAX_MONEY = 280320000 * COIN
 
 MAX_BIP125_RBF_SEQUENCE = 0xfffffffd  # Sequence number that is rbf-opt-in (BIP 125) and csv-opt-out (BIP 68)
 MAX_SEQUENCE_NONFINAL = 0xfffffffe  # Sequence number that is csv-opt-out (BIP 68)
@@ -684,7 +684,7 @@ class CTransaction:
 
     def is_valid(self):
         for tout in self.vout:
-            if tout.nValue < 0 or tout.nValue > 21000000 * COIN:
+            if tout.nValue < 0 or tout.nValue > MAX_MONEY:
                 return False
         return True
 


### PR DESCRIPTION
## Summary
- extend subsidy halving interval to 2,803,200 blocks
- raise MAX_MONEY and update tests and utilities for new supply
- document new halving schedule

## Testing
- `python3 -m unittest test_framework.compressor`
- `python3 -m py_compile test/functional/mempool_limit.py`
- `python3 -m py_compile test/functional/test_framework/messages.py`
- `cmake --build build --target test_bitcoin` *(failed: build stopped: interrupted by user)*

------
https://chatgpt.com/codex/tasks/task_e_68b15f8aec90832db53404df30d0ce77