### PR TITLE
Remove redundant uint256 include

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -20,7 +20,6 @@
 #include <uint256.h>
 #include <util/chaintype.h>
 #include <util/strencodings.h>
-#include <uint256.h>
 #include <common/args.h>
 
 


### PR DESCRIPTION
## Summary
- Clean up `chainparams.cpp` by removing a duplicate `uint256` header include

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Boost")*


------
https://chatgpt.com/codex/tasks/task_e_68b16453708c832dbf656db27073fbfb