### PR TITLE
Increase fee field mask for ADO fee range

### DIFF
--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -212,8 +212,8 @@ struct DepGraphFormatter
                 // Read fee, encoded as an unsigned varint (odd=negative, even=non-negative).
                 uint64_t coded_fee;
                 s >> VARINT(coded_fee);
-                coded_fee &= 0xFFFFFFFFFFFFF; // Enough for fee between -280M...280M ADO.
-                static_assert(0xFFFFFFFFFFFFF > uint64_t{2} * 280320000 * 100000000);
+                coded_fee &= 0xFFFFFFFFFFFFFF; // Enough for fee between -280M...280M ADO.
+                static_assert(0xFFFFFFFFFFFFFF > uint64_t{2} * 280320000 * 100000000);
                 new_feerate = {UnsignedToSigned(coded_fee), size};
                 // Read dependency information.
                 auto topo_idx = reordering.size();


### PR DESCRIPTION
## Summary
- expand DepGraph fee field mask to handle Adonai’s larger money supply

## Testing
- `g++ -std=c++20 -I src -I src/test -c src/test/cluster_linearize_tests.cpp -o /tmp/cluster_linearize_tests.o`
- `ls -l /tmp/cluster_linearize_tests.o`


------
https://chatgpt.com/codex/tasks/task_e_68b1ec93f250832db285b6daecfe9756