### PR TITLE
Refactor ZMQ to Adonai naming

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2023-present The Bitcoin Core developers
+# Modifications (c) 2025 The Adonai Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
@@ -353,7 +354,7 @@ target_link_libraries(bitcoin_node
     core_interface
     bitcoin_common
     bitcoin_util
-    $<TARGET_NAME_IF_EXISTS:bitcoin_zmq>
+    $<TARGET_NAME_IF_EXISTS:adonai_zmq>
     leveldb
     minisketch
     univalue

--- a/src/zmq/CMakeLists.txt
+++ b/src/zmq/CMakeLists.txt
@@ -1,19 +1,20 @@
 # Copyright (c) 2023-present The Bitcoin Core developers
+# Modifications (c) 2025 The Adonai Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_library(bitcoin_zmq STATIC EXCLUDE_FROM_ALL
+add_library(adonai_zmq STATIC EXCLUDE_FROM_ALL
   zmqabstractnotifier.cpp
   zmqnotificationinterface.cpp
   zmqpublishnotifier.cpp
   zmqrpc.cpp
   zmqutil.cpp
 )
-target_compile_definitions(bitcoin_zmq
+target_compile_definitions(adonai_zmq
   INTERFACE
     ENABLE_ZMQ=1
 )
-target_link_libraries(bitcoin_zmq
+target_link_libraries(adonai_zmq
   PRIVATE
     core_interface
     univalue

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H
-#define BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H
+#ifndef ADONAI_ZMQ_ZMQABSTRACTNOTIFIER_H
+#define ADONAI_ZMQ_ZMQABSTRACTNOTIFIER_H
 
 #include <cstdint>
 #include <functional>
@@ -65,4 +65,4 @@ protected:
     int outbound_message_high_water_mark; // aka SNDHWM
 };
 
-#endif // BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H
+#endif // ADONAI_ZMQ_ZMQABSTRACTNOTIFIER_H

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
-#define BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
+#ifndef ADONAI_ZMQ_ZMQNOTIFICATIONINTERFACE_H
+#define ADONAI_ZMQ_ZMQNOTIFICATIONINTERFACE_H
 
 #include <primitives/transaction.h>
 #include <validationinterface.h>
@@ -49,4 +49,4 @@ private:
 
 extern std::unique_ptr<CZMQNotificationInterface> g_zmq_notification_interface;
 
-#endif // BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
+#endif // ADONAI_ZMQ_ZMQNOTIFICATIONINTERFACE_H

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H
-#define BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H
+#ifndef ADONAI_ZMQ_ZMQPUBLISHNOTIFIER_H
+#define ADONAI_ZMQ_ZMQPUBLISHNOTIFIER_H
 
 #include <zmq/zmqabstractnotifier.h>
 
@@ -73,4 +73,4 @@ public:
     bool NotifyTransactionRemoval(const CTransaction &transaction, uint64_t mempool_sequence) override;
 };
 
-#endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H
+#endif // ADONAI_ZMQ_ZMQPUBLISHNOTIFIER_H

--- a/src/zmq/zmqrpc.h
+++ b/src/zmq/zmqrpc.h
@@ -3,11 +3,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_ZMQ_ZMQRPC_H
-#define BITCOIN_ZMQ_ZMQRPC_H
+#ifndef ADONAI_ZMQ_ZMQRPC_H
+#define ADONAI_ZMQ_ZMQRPC_H
 
 class CRPCTable;
 
 void RegisterZMQRPCCommands(CRPCTable& t);
 
-#endif // BITCOIN_ZMQ_ZMQRPC_H
+#endif // ADONAI_ZMQ_ZMQRPC_H

--- a/src/zmq/zmqutil.h
+++ b/src/zmq/zmqutil.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_ZMQ_ZMQUTIL_H
-#define BITCOIN_ZMQ_ZMQUTIL_H
+#ifndef ADONAI_ZMQ_ZMQUTIL_H
+#define ADONAI_ZMQ_ZMQUTIL_H
 
 #include <string>
 
@@ -13,4 +13,4 @@ void zmqError(const std::string& str);
 /** Prefix for unix domain socket addresses (which are local filesystem paths) */
 const std::string ADDR_PREFIX_IPC = "ipc://"; // used by libzmq, example "ipc:///root/path/to/file"
 
-#endif // BITCOIN_ZMQ_ZMQUTIL_H
+#endif // ADONAI_ZMQ_ZMQUTIL_H


### PR DESCRIPTION
## Summary
- Rename ZMQ include guards from BITCOIN to ADONAI
- Switch ZMQ CMake target to `adonai_zmq` and update linkage
- Add Adonai modifications header to CMake files

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Boost" (requested version 1.73.0))*

------
https://chatgpt.com/codex/tasks/task_e_68b1f29230d8832dad1c925bad8c609b