### PR TITLE
Fix wallet build link dependency

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(adonai_wallet STATIC EXCLUDE_FROM_ALL
 target_link_libraries(adonai_wallet
   PRIVATE
     core_interface
-    adonai_common
+    bitcoin_common
     $<TARGET_NAME_IF_EXISTS:unofficial::sqlite3::sqlite3>
     $<TARGET_NAME_IF_EXISTS:SQLite::SQLite3>
     univalue


### PR DESCRIPTION
## Summary
- fix wallet library to link against existing bitcoin_common library

## Testing
- `cmake --build build --target bitcoin-wallet -j$(nproc)`
- `ctest -j$(nproc) --output-on-failure` *(fails: Unable to find executable)*


------
https://chatgpt.com/codex/tasks/task_e_68b201cf15ac832d918c94e646b97b07