### PR TITLE
Fix spelling issues in docs and comments

### DIFF
--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2014 Wladimir J. van der Laan
+# codespell:ignore=lief
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''

--- a/depends/patches/libxcb/remove_pthread_stubs.patch
+++ b/depends/patches/libxcb/remove_pthread_stubs.patch
@@ -1,4 +1,4 @@
-Remove uneeded pthread-stubs dependency
+Remove unneeded pthread-stubs dependency
 --- a/configure
 +++ b/configure
 @@ -19695,7 +19695,7 @@ fi

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -59,7 +59,7 @@ outgoing connections, but more is possible.
         service provider.
         ------------------------------------------------------------------------
 
-If -proxy or -onion is specified multiple times, later occurences override
+If -proxy or -onion is specified multiple times, later occurrences override
 earlier ones and command line overrides the config file. UNIX domain sockets may
 be used for proxy connections. Set `-onion` or `-proxy` to the local socket path
 with the prefix `unix:` (e.g. `-onion=unix:/home/me/torsocket`).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
   target_compile_options(blake3_sse41  PRIVATE -msse4.1)
   add_library(blake3_avx2   OBJECT blake3/blake3_avx2.c)
   target_compile_options(blake3_avx2   PRIVATE -mavx2)
-  # (opcional: AVX-512 si te interesa)
+  # (optional: AVX-512 if desired)
   target_sources(blake3 PRIVATE
     $<TARGET_OBJECTS:blake3_sse2>
     $<TARGET_OBJECTS:blake3_sse41>

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -83,9 +83,9 @@ struct BIP9Deployment {
  */
 struct Params {
     int64_t nPowTargetSpacingV1;      // 120
-    int32_t nPowSpacingSwitchHeight;  // altura del cambio
-    int64_t  nSubsidyInitial;          // subsidio inicial por bloque
-    int nCoinbaseMaturity;            // madurez de coinbase en bloques
+    int32_t nPowSpacingSwitchHeight;  // spacing change height
+    int64_t  nSubsidyInitial;         // initial block subsidy
+    int nCoinbaseMaturity;            // coinbase maturity in blocks
 
     uint256 hashGenesisBlock;
     int nSubsidyHalvingInterval;

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -575,15 +575,15 @@ public:
             .dTxRate = 0.0,
         };
 
-        // ----- PREFIJOS DIRECCIONES -----
-        // Base58 (no críticos si te vas a Bech32; usa valores no colisionantes con BTC):
+        // ----- ADDRESS PREFIXES -----
+        // Base58 (not critical if using Bech32; use values that don't collide with BTC):
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 65);  // 'A' (~ADO signet)
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 125);
         base58Prefixes[SECRET_KEY]     = std::vector<unsigned char>(1, 153);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x88, 0xB2, 0x1E}; // xpub (placeholder)
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4}; // xprv (placeholder)
 
-        // Bech32 HRP propia para signet ADONAI
+        // Custom Bech32 HRP for ADONAI signet
         bech32_hrp = "sado";
 
         fDefaultConsistencyChecks = false;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -42,8 +42,8 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
 {
-    // Regla de dificultad fija para testnet y BLAKE3
-    // 0x207fffff corresponde a la dificultad más baja (es decir, target más alto posible)
+    // Fixed difficulty rule for testnet and BLAKE3
+    // 0x207fffff corresponds to the lowest difficulty (i.e., highest possible target)
     return 0x207fffff;
 }
 
@@ -55,7 +55,7 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&
 
     bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
 
-    // Verificación estándar del target
+    // Standard target verification
     if (fNegative || bnTarget == 0 || fOverflow || UintToArith256(hash) > bnTarget)
         return false;
 

--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -18,6 +18,8 @@ nd
 nin
 ot
 outIn
+ges
+OUTIN
 requestor
 ser
 siz


### PR DESCRIPTION
## Summary
- fix spelling mistakes and translate remaining Spanish comments to English
- extend lint ignore list for words used intentionally

## Testing
- `python3 test/lint/lint-spelling.py && echo lint-spelling passed`

------
https://chatgpt.com/codex/tasks/task_e_68b207c778a8832da5773a0de3e6c67b