### PR TITLE
refactor: rename util to adonai

### DIFF
--- a/contrib/devtools/check-deps.sh
+++ b/contrib/devtools/check-deps.sh
@@ -10,7 +10,7 @@ LIBS[common]="libbitcoin_common.a"
 LIBS[consensus]="libbitcoin_consensus.a"
 LIBS[crypto]="libbitcoin_crypto.a"
 LIBS[node]="libbitcoin_node.a"
-LIBS[util]="libbitcoin_util.a"
+LIBS[util]="libadonai_util.a"
 LIBS[wallet]="libbitcoin_wallet.a"
 
 # Declare allowed dependencies "X Y" where X is allowed to depend on Y. This

--- a/doc/design/libraries.md
+++ b/doc/design/libraries.md
@@ -3,14 +3,14 @@
 | Name                     | Description |
 |--------------------------|-------------|
 | *libbitcoin_cli*         | RPC client functionality used by *bitcoin-cli* executable |
-| *libbitcoin_common*      | Home for common functionality shared by different executables and libraries. Similar to *libbitcoin_util*, but higher-level (see [Dependencies](#dependencies)). |
+| *libbitcoin_common*      | Home for common functionality shared by different executables and libraries. Similar to *libadonai_util*, but higher-level (see [Dependencies](#dependencies)). |
 | *libbitcoin_consensus*   | Consensus functionality used by *libbitcoin_node* and *libbitcoin_wallet*. |
 | *libbitcoin_crypto*      | Hardware-optimized functions for data encryption, hashing, message authentication, and key derivation. |
 | *libbitcoin_kernel*      | Consensus engine and support library used for validation by *libbitcoin_node*. |
 | *libbitcoinqt*           | GUI functionality used by *bitcoin-qt* and *bitcoin-gui* executables. |
 | *libbitcoin_ipc*         | IPC functionality used by *bitcoin-node*, *bitcoin-wallet*, *bitcoin-gui* executables to communicate when [`-DENABLE_IPC=ON`](multiprocess.md) is used. |
 | *libbitcoin_node*        | P2P and RPC server functionality used by *bitcoind* and *bitcoin-qt* executables. |
-| *libbitcoin_util*        | Home for common functionality shared by different executables and libraries. Similar to *libbitcoin_common*, but lower-level (see [Dependencies](#dependencies)). |
+| *libadonai_util*        | Home for common functionality shared by different executables and libraries. Similar to *libbitcoin_common*, but lower-level (see [Dependencies](#dependencies)). |
 | *libbitcoin_wallet*      | Wallet functionality used by *bitcoind* and *bitcoin-wallet* executables. |
 | *libbitcoin_wallet_tool* | Lower-level wallet functionality used by *bitcoin-wallet* executable. |
 | *libbitcoin_zmq*         | [ZeroMQ](../zmq.md) functionality used by *bitcoind* and *bitcoin-qt* executables. |
@@ -24,7 +24,7 @@
   - *libbitcoin_node* code lives in `src/node/` in the `node::` namespace
   - *libbitcoin_wallet* code lives in `src/wallet/` in the `wallet::` namespace
   - *libbitcoin_ipc* code lives in `src/ipc/` in the `ipc::` namespace
-  - *libbitcoin_util* code lives in `src/util/` in the `util::` namespace
+  - *libadonai_util* code lives in `src/util/` in the `util::` namespace
   - *libbitcoin_consensus* code lives in `src/consensus/` in the `Consensus::` namespace
 
 ## Dependencies
@@ -51,36 +51,36 @@ bitcoin-qt[bitcoin-qt]-->libbitcoin_wallet;
 bitcoin-wallet[bitcoin-wallet]-->libbitcoin_wallet;
 bitcoin-wallet[bitcoin-wallet]-->libbitcoin_wallet_tool;
 
-libbitcoin_cli-->libbitcoin_util;
+libbitcoin_cli-->libadonai_util;
 libbitcoin_cli-->libbitcoin_common;
 
 libbitcoin_consensus-->libbitcoin_crypto;
 
 libbitcoin_common-->libbitcoin_consensus;
 libbitcoin_common-->libbitcoin_crypto;
-libbitcoin_common-->libbitcoin_util;
+libbitcoin_common-->libadonai_util;
 
 libbitcoin_kernel-->libbitcoin_consensus;
 libbitcoin_kernel-->libbitcoin_crypto;
-libbitcoin_kernel-->libbitcoin_util;
+libbitcoin_kernel-->libadonai_util;
 
 libbitcoin_node-->libbitcoin_consensus;
 libbitcoin_node-->libbitcoin_crypto;
 libbitcoin_node-->libbitcoin_kernel;
 libbitcoin_node-->libbitcoin_common;
-libbitcoin_node-->libbitcoin_util;
+libbitcoin_node-->libadonai_util;
 
 libbitcoinqt-->libbitcoin_common;
-libbitcoinqt-->libbitcoin_util;
+libbitcoinqt-->libadonai_util;
 
-libbitcoin_util-->libbitcoin_crypto;
+libadonai_util-->libbitcoin_crypto;
 
 libbitcoin_wallet-->libbitcoin_common;
 libbitcoin_wallet-->libbitcoin_crypto;
-libbitcoin_wallet-->libbitcoin_util;
+libbitcoin_wallet-->libadonai_util;
 
 libbitcoin_wallet_tool-->libbitcoin_wallet;
-libbitcoin_wallet_tool-->libbitcoin_util;
+libbitcoin_wallet_tool-->libadonai_util;
 
 classDef bold stroke-width:2px, font-weight:bold, font-size: smaller;
 class bitcoin-qt,bitcoind,bitcoin-cli,bitcoin-wallet bold
@@ -97,13 +97,13 @@ class bitcoin-qt,bitcoind,bitcoin-cli,bitcoin-wallet bold
 
 - *libbitcoin_consensus* should only depend on *libbitcoin_crypto*, and all other libraries besides *libbitcoin_crypto* should be allowed to depend on it.
 
-- *libbitcoin_util* should be a standalone dependency that any library can depend on, and it should not depend on other libraries except *libbitcoin_crypto*. It provides basic utilities that fill in gaps in the C++ standard library and provide lightweight abstractions over platform-specific features. Since the util library is distributed with the kernel and is usable by kernel applications, it shouldn't contain functions that external code shouldn't call, like higher level code targeted at the node or wallet. (*libbitcoin_common* is a better place for higher level code, or code that is meant to be used by internal applications only.)
+- *libadonai_util* should be a standalone dependency that any library can depend on, and it should not depend on other libraries except *libbitcoin_crypto*. It provides basic utilities that fill in gaps in the C++ standard library and provide lightweight abstractions over platform-specific features. Since the util library is distributed with the kernel and is usable by kernel applications, it shouldn't contain functions that external code shouldn't call, like higher level code targeted at the node or wallet. (*libbitcoin_common* is a better place for higher level code, or code that is meant to be used by internal applications only.)
 
-- *libbitcoin_common* is a home for miscellaneous shared code used by different Bitcoin Core applications. It should not depend on anything other than *libbitcoin_util*, *libbitcoin_consensus*, and *libbitcoin_crypto*.
+- *libbitcoin_common* is a home for miscellaneous shared code used by different Bitcoin Core applications. It should not depend on anything other than *libadonai_util*, *libbitcoin_consensus*, and *libbitcoin_crypto*.
 
-- *libbitcoin_kernel* should only depend on *libbitcoin_util*, *libbitcoin_consensus*, and *libbitcoin_crypto*.
+- *libbitcoin_kernel* should only depend on *libadonai_util*, *libbitcoin_consensus*, and *libbitcoin_crypto*.
 
-- The only thing that should depend on *libbitcoin_kernel* internally should be *libbitcoin_node*. GUI and wallet libraries *libbitcoinqt* and *libbitcoin_wallet* in particular should not depend on *libbitcoin_kernel* and the unneeded functionality it would pull in, like block validation. To the extent that GUI and wallet code need scripting and signing functionality, they should be able to get it from *libbitcoin_consensus*, *libbitcoin_common*, *libbitcoin_crypto*, and *libbitcoin_util*, instead of *libbitcoin_kernel*.
+- The only thing that should depend on *libbitcoin_kernel* internally should be *libbitcoin_node*. GUI and wallet libraries *libbitcoinqt* and *libbitcoin_wallet* in particular should not depend on *libbitcoin_kernel* and the unneeded functionality it would pull in, like block validation. To the extent that GUI and wallet code need scripting and signing functionality, they should be able to get it from *libbitcoin_consensus*, *libbitcoin_common*, *libbitcoin_crypto*, and *libadonai_util*, instead of *libbitcoin_kernel*.
 
 - GUI, node, and wallet code internal implementations should all be independent of each other, and the *libbitcoinqt*, *libbitcoin_node*, *libbitcoin_wallet* libraries should never reference each other's symbols. They should only call each other through [`src/interfaces/`](../../src/interfaces/) abstract interfaces.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,7 +158,7 @@ if(WITH_ZMQ)
 endif()
 
 # Home for common functionality shared by different executables and libraries.
-# Similar to `bitcoin_util` library, but higher-level.
+# Similar to `adonai_util` library, but higher-level.
 add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   addresstype.cpp
   base58.cpp
@@ -217,7 +217,7 @@ target_link_libraries(bitcoin_common
   PRIVATE
     core_interface
     bitcoin_consensus
-    bitcoin_util
+    adonai_util
     univalue
     secp256k1
     Boost::headers
@@ -244,7 +244,7 @@ if(ENABLE_WALLET)
       core_interface
       adonai_wallet
       bitcoin_common
-      bitcoin_util
+      adonai_util
       Boost::headers
     )
     install_binary_component(bitcoin-wallet HAS_MANPAGE)
@@ -353,7 +353,7 @@ target_link_libraries(bitcoin_node
   PRIVATE
     core_interface
     bitcoin_common
-    bitcoin_util
+    adonai_util
     $<TARGET_NAME_IF_EXISTS:adonai_zmq>
     leveldb
     minisketch
@@ -370,7 +370,7 @@ if(BUILD_BITCOIN_BIN)
   add_executable(bitcoin bitcoin.cpp)
   add_windows_resources(bitcoin bitcoin-res.rc)
   add_windows_application_manifest(bitcoin)
-  target_link_libraries(bitcoin core_interface bitcoin_util)
+  target_link_libraries(bitcoin core_interface adonai_util)
   install_binary_component(bitcoin)
 endif()
 
@@ -441,7 +441,7 @@ if(BUILD_CLI)
     core_interface
     bitcoin_cli
     bitcoin_common
-    bitcoin_util
+    adonai_util
     blake3
     libevent::core
     libevent::extra
@@ -457,7 +457,7 @@ if(BUILD_TX)
   target_link_libraries(bitcoin-tx
     core_interface
     bitcoin_common
-    bitcoin_util
+    adonai_util
     univalue
     blake3
   )
@@ -474,7 +474,7 @@ if(BUILD_UTIL)
     blake3
     core_interface
     bitcoin_common
-    bitcoin_util
+    adonai_util
   )
   install_binary_component(bitcoin-util HAS_MANPAGE)
 endif()

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2023-present The Bitcoin Core developers
+# Modifications (c) 2025 The Adonai Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
@@ -140,7 +141,7 @@ target_link_libraries(fuzz
   test_fuzz
   bitcoin_cli
   bitcoin_common
-  bitcoin_util
+  adonai_util
   minisketch
   leveldb
   univalue

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,8 +1,9 @@
 # Copyright (c) 2023-present The Bitcoin Core developers
+# Modifications (c) 2025 The Adonai Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
+add_library(adonai_util STATIC EXCLUDE_FROM_ALL
   asmap.cpp
   batchpriority.cpp
   bip32.cpp
@@ -37,7 +38,7 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   ../sync.cpp
 )
 
-target_link_libraries(bitcoin_util
+target_link_libraries(adonai_util
   PRIVATE
     core_interface
     bitcoin_clientversion

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -24,7 +24,7 @@ static std::string FormatException(const std::exception* pex, std::string_view t
     char pszModule[MAX_PATH] = "";
     GetModuleFileNameA(nullptr, pszModule, sizeof(pszModule));
 #else
-    const char* pszModule = "bitcoin";
+    const char* pszModule = "adonai";
 #endif
     if (pex)
         return strprintf(


### PR DESCRIPTION
## Summary
- rename util static library and related build references from bitcoin to adonai
- adjust exception module tag to "adonai"
- update documentation and scripts for new util name

## Testing
- `cmake -S . -B build`
- `cmake --build build --target adonai_util`


------
https://chatgpt.com/codex/tasks/task_e_68b1fb6b8d08832d99a1f28e55db610a