### PR TITLE
refactor: rename bitcoin primitives to adonai

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CLIENTVERSION_H
-#define BITCOIN_CLIENTVERSION_H
+#ifndef ADONAI_CLIENTVERSION_H
+#define ADONAI_CLIENTVERSION_H
 
 #include <util/macros.h>
 
@@ -42,4 +42,4 @@ std::string LicenseInfo();
 
 #endif // RC_INVOKED
 
-#endif // BITCOIN_CLIENTVERSION_H
+#endif // ADONAI_CLIENTVERSION_H

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Modifications (c) 2025 The Adonai Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <primitives/block.h>
 
 #include <serialize.h>

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_PRIMITIVES_BLOCK_H
-#define BITCOIN_PRIMITIVES_BLOCK_H
+#ifndef ADONAI_PRIMITIVES_BLOCK_H
+#define ADONAI_PRIMITIVES_BLOCK_H
 
 #include <primitives/transaction.h>
 #include <serialize.h>
@@ -156,4 +156,4 @@ struct CBlockLocator
     }
 };
 
-#endif // BITCOIN_PRIMITIVES_BLOCK_H
+#endif // ADONAI_PRIMITIVES_BLOCK_H

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_PRIMITIVES_TRANSACTION_H
-#define BITCOIN_PRIMITIVES_TRANSACTION_H
+#ifndef ADONAI_PRIMITIVES_TRANSACTION_H
+#define ADONAI_PRIMITIVES_TRANSACTION_H
 
 #include <attributes.h>
 #include <consensus/amount.h>
@@ -424,4 +424,4 @@ struct CMutableTransaction
 typedef std::shared_ptr<const CTransaction> CTransactionRef;
 template <typename Tx> static inline CTransactionRef MakeTransactionRef(Tx&& txIn) { return std::make_shared<const CTransaction>(std::forward<Tx>(txIn)); }
 
-#endif // BITCOIN_PRIMITIVES_TRANSACTION_H
+#endif // ADONAI_PRIMITIVES_TRANSACTION_H


### PR DESCRIPTION
## Summary
- rename primitive header guards from BITCOIN to ADONAI and add Adonai license header
- update clientversion guard to ADONAI
- ensure block implementation carries MIT notice

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build --target bitcoin_clientversion`


------
https://chatgpt.com/codex/tasks/task_e_68b219b042e4832d8883d5c9ea8db158