### PR TITLE
refactor: rename bitcoin script references to adonai

### DIFF
--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SCRIPT_DESCRIPTOR_H
-#define BITCOIN_SCRIPT_DESCRIPTOR_H
+#ifndef ADONAI_SCRIPT_DESCRIPTOR_H
+#define ADONAI_SCRIPT_DESCRIPTOR_H
 
 #include <outputtype.h>
 #include <script/script.h>
@@ -207,4 +207,4 @@ std::unique_ptr<Descriptor> InferDescriptor(const CScript& script, const Signing
 */
 uint256 DescriptorID(const Descriptor& desc);
 
-#endif // BITCOIN_SCRIPT_DESCRIPTOR_H
+#endif // ADONAI_SCRIPT_DESCRIPTOR_H

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SCRIPT_INTERPRETER_H
-#define BITCOIN_SCRIPT_INTERPRETER_H
+#ifndef ADONAI_SCRIPT_INTERPRETER_H
+#define ADONAI_SCRIPT_INTERPRETER_H
 
 #include <consensus/amount.h>
 #include <hash.h>
@@ -352,4 +352,4 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
 
 int FindAndDelete(CScript& script, const CScript& b);
 
-#endif // BITCOIN_SCRIPT_INTERPRETER_H
+#endif // ADONAI_SCRIPT_INTERPRETER_H

--- a/src/script/keyorigin.h
+++ b/src/script/keyorigin.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SCRIPT_KEYORIGIN_H
-#define BITCOIN_SCRIPT_KEYORIGIN_H
+#ifndef ADONAI_SCRIPT_KEYORIGIN_H
+#define ADONAI_SCRIPT_KEYORIGIN_H
 
 #include <serialize.h>
 #include <vector>
@@ -47,4 +47,4 @@ struct KeyOriginInfo
     }
 };
 
-#endif // BITCOIN_SCRIPT_KEYORIGIN_H
+#endif // ADONAI_SCRIPT_KEYORIGIN_H

--- a/src/script/miniscript.h
+++ b/src/script/miniscript.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SCRIPT_MINISCRIPT_H
-#define BITCOIN_SCRIPT_MINISCRIPT_H
+#ifndef ADONAI_SCRIPT_MINISCRIPT_H
+#define ADONAI_SCRIPT_MINISCRIPT_H
 
 #include <algorithm>
 #include <compare>
@@ -2248,7 +2248,7 @@ enum class DecodeContext {
     ENDIF_ELSE,
 };
 
-//! Parse a miniscript from a bitcoin script
+//! Parse a miniscript from an adonai script
 template<typename Key, typename Ctx, typename I>
 inline NodeRef<Key> DecodeScript(I& in, I last, const Ctx& ctx)
 {
@@ -2659,4 +2659,4 @@ inline NodeRef<typename Ctx::Key> FromScript(const CScript& script, const Ctx& c
 
 } // namespace miniscript
 
-#endif // BITCOIN_SCRIPT_MINISCRIPT_H
+#endif // ADONAI_SCRIPT_MINISCRIPT_H

--- a/src/script/parsing.h
+++ b/src/script/parsing.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SCRIPT_PARSING_H
-#define BITCOIN_SCRIPT_PARSING_H
+#ifndef ADONAI_SCRIPT_PARSING_H
+#define ADONAI_SCRIPT_PARSING_H
 
 #include <span.h>
 
@@ -38,4 +38,4 @@ std::span<const char> Expr(std::span<const char>& sp);
 
 } // namespace script
 
-#endif // BITCOIN_SCRIPT_PARSING_H
+#endif // ADONAI_SCRIPT_PARSING_H

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SCRIPT_SCRIPT_H
-#define BITCOIN_SCRIPT_SCRIPT_H
+#ifndef ADONAI_SCRIPT_SCRIPT_H
+#define ADONAI_SCRIPT_SCRIPT_H
 
 #include <attributes.h>
 #include <crypto/common.h>
@@ -531,7 +531,7 @@ public:
     }
 
     /**
-     * Pre-version-0.6, Bitcoin always counted CHECKMULTISIGs
+     * Pre-version-0.6, Adonai always counted CHECKMULTISIGs
      * as 20 sigops. With pay-to-script-hash, that changed:
      * CHECKMULTISIGs serialized in scriptSigs are
      * counted more accurately, assuming they are of the form
@@ -639,4 +639,4 @@ CScript BuildScript(Ts&&... inputs)
     return ret;
 }
 
-#endif // BITCOIN_SCRIPT_SCRIPT_H
+#endif // ADONAI_SCRIPT_SCRIPT_H

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SCRIPT_SCRIPT_ERROR_H
-#define BITCOIN_SCRIPT_SCRIPT_ERROR_H
+#ifndef ADONAI_SCRIPT_SCRIPT_ERROR_H
+#define ADONAI_SCRIPT_SCRIPT_ERROR_H
 
 #include <string>
 
@@ -90,4 +90,4 @@ typedef enum ScriptError_t
 
 std::string ScriptErrorString(const ScriptError error);
 
-#endif // BITCOIN_SCRIPT_SCRIPT_ERROR_H
+#endif // ADONAI_SCRIPT_SCRIPT_ERROR_H

--- a/src/script/sigcache.h
+++ b/src/script/sigcache.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SCRIPT_SIGCACHE_H
-#define BITCOIN_SCRIPT_SIGCACHE_H
+#ifndef ADONAI_SCRIPT_SIGCACHE_H
+#define ADONAI_SCRIPT_SIGCACHE_H
 
 #include <consensus/amount.h>
 #include <crypto/sha256.h>
@@ -74,4 +74,4 @@ public:
     bool VerifySchnorrSignature(std::span<const unsigned char> sig, const XOnlyPubKey& pubkey, const uint256& sighash) const override;
 };
 
-#endif // BITCOIN_SCRIPT_SIGCACHE_H
+#endif // ADONAI_SCRIPT_SIGCACHE_H

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SCRIPT_SIGN_H
-#define BITCOIN_SCRIPT_SIGN_H
+#ifndef ADONAI_SCRIPT_SIGN_H
+#define ADONAI_SCRIPT_SIGN_H
 
 #include <attributes.h>
 #include <coins.h>
@@ -108,4 +108,4 @@ bool IsSegWitOutput(const SigningProvider& provider, const CScript& script);
 /** Sign the CMutableTransaction */
 bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* provider, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors);
 
-#endif // BITCOIN_SCRIPT_SIGN_H
+#endif // ADONAI_SCRIPT_SIGN_H

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SCRIPT_SIGNINGPROVIDER_H
-#define BITCOIN_SCRIPT_SIGNINGPROVIDER_H
+#ifndef ADONAI_SCRIPT_SIGNINGPROVIDER_H
+#define ADONAI_SCRIPT_SIGNINGPROVIDER_H
 
 #include <addresstype.h>
 #include <attributes.h>
@@ -317,4 +317,4 @@ public:
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
 };
 
-#endif // BITCOIN_SCRIPT_SIGNINGPROVIDER_H
+#endif // ADONAI_SCRIPT_SIGNINGPROVIDER_H

--- a/src/script/solver.h
+++ b/src/script/solver.h
@@ -6,8 +6,8 @@
 
 // The Solver functions are used by policy and the wallet, but not consensus.
 
-#ifndef BITCOIN_SCRIPT_SOLVER_H
-#define BITCOIN_SCRIPT_SOLVER_H
+#ifndef ADONAI_SCRIPT_SOLVER_H
+#define ADONAI_SCRIPT_SOLVER_H
 
 #include <attributes.h>
 #include <script/script.h>
@@ -65,4 +65,4 @@ std::optional<std::pair<int, std::vector<std::span<const unsigned char>>>> Match
 /** Generate a multisig script. */
 CScript GetScriptForMultisig(int nRequired, const std::vector<CPubKey>& keys);
 
-#endif // BITCOIN_SCRIPT_SOLVER_H
+#endif // ADONAI_SCRIPT_SOLVER_H


### PR DESCRIPTION
## Summary
- rename `BITCOIN_SCRIPT_*` include guards to `ADONAI_SCRIPT_*`
- update script comments to refer to Adonai instead of Bitcoin

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Boost" (requested version 1.73.0))*

------
https://chatgpt.com/codex/tasks/task_e_68b20c6e0cac832dba56ce72d5978c4b