### PR TITLE
Refactor node module for Adonai naming

### DIFF
--- a/src/node/abort.h
+++ b/src/node/abort.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_ABORT_H
-#define BITCOIN_NODE_ABORT_H
+#ifndef ADONAI_NODE_ABORT_H
+#define ADONAI_NODE_ABORT_H
 
 #include <atomic>
 #include <functional>
@@ -16,4 +16,4 @@ class Warnings;
 void AbortNode(const std::function<bool()>& shutdown_request, std::atomic<int>& exit_status, const bilingual_str& message, node::Warnings* warnings);
 } // namespace node
 
-#endif // BITCOIN_NODE_ABORT_H
+#endif // ADONAI_NODE_ABORT_H

--- a/src/node/blockmanager_args.h
+++ b/src/node/blockmanager_args.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_BLOCKMANAGER_ARGS_H
-#define BITCOIN_NODE_BLOCKMANAGER_ARGS_H
+#ifndef ADONAI_NODE_BLOCKMANAGER_ARGS_H
+#define ADONAI_NODE_BLOCKMANAGER_ARGS_H
 
 #include <node/blockstorage.h>
 #include <util/result.h>
@@ -16,4 +16,4 @@ namespace node {
 [[nodiscard]] util::Result<void> ApplyArgsManOptions(const ArgsManager& args, BlockManager::Options& opts);
 } // namespace node
 
-#endif // BITCOIN_NODE_BLOCKMANAGER_ARGS_H
+#endif // ADONAI_NODE_BLOCKMANAGER_ARGS_H

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_BLOCKSTORAGE_H
-#define BITCOIN_NODE_BLOCKSTORAGE_H
+#ifndef ADONAI_NODE_BLOCKSTORAGE_H
+#define ADONAI_NODE_BLOCKSTORAGE_H
 
 #include <attributes.h>
 #include <chain.h>
@@ -425,4 +425,4 @@ public:
 void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_paths);
 } // namespace node
 
-#endif // BITCOIN_NODE_BLOCKSTORAGE_H
+#endif // ADONAI_NODE_BLOCKSTORAGE_H

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_CACHES_H
-#define BITCOIN_NODE_CACHES_H
+#ifndef ADONAI_NODE_CACHES_H
+#define ADONAI_NODE_CACHES_H
 
 #include <kernel/caches.h>
 #include <util/byte_units.h>
@@ -30,4 +30,4 @@ struct CacheSizes {
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes = 0);
 } // namespace node
 
-#endif // BITCOIN_NODE_CACHES_H
+#endif // ADONAI_NODE_CACHES_H

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_CHAINSTATE_H
-#define BITCOIN_NODE_CHAINSTATE_H
+#ifndef ADONAI_NODE_CHAINSTATE_H
+#define ADONAI_NODE_CHAINSTATE_H
 
 #include <util/translation.h>
 #include <validation.h>
@@ -72,4 +72,4 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const kernel::C
 ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
 } // namespace node
 
-#endif // BITCOIN_NODE_CHAINSTATE_H
+#endif // ADONAI_NODE_CHAINSTATE_H

--- a/src/node/chainstatemanager_args.h
+++ b/src/node/chainstatemanager_args.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_CHAINSTATEMANAGER_ARGS_H
-#define BITCOIN_NODE_CHAINSTATEMANAGER_ARGS_H
+#ifndef ADONAI_NODE_CHAINSTATEMANAGER_ARGS_H
+#define ADONAI_NODE_CHAINSTATEMANAGER_ARGS_H
 
 #include <util/result.h>
 #include <validation.h>
@@ -18,4 +18,4 @@ namespace node {
 [[nodiscard]] util::Result<void> ApplyArgsManOptions(const ArgsManager& args, ChainstateManager::Options& opts);
 } // namespace node
 
-#endif // BITCOIN_NODE_CHAINSTATEMANAGER_ARGS_H
+#endif // ADONAI_NODE_CHAINSTATEMANAGER_ARGS_H

--- a/src/node/coin.h
+++ b/src/node/coin.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_COIN_H
-#define BITCOIN_NODE_COIN_H
+#ifndef ADONAI_NODE_COIN_H
+#define ADONAI_NODE_COIN_H
 
 #include <map>
 
@@ -25,4 +25,4 @@ struct NodeContext;
 void FindCoins(const node::NodeContext& node, std::map<COutPoint, Coin>& coins);
 } // namespace node
 
-#endif // BITCOIN_NODE_COIN_H
+#endif // ADONAI_NODE_COIN_H

--- a/src/node/coins_view_args.h
+++ b/src/node/coins_view_args.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_COINS_VIEW_ARGS_H
-#define BITCOIN_NODE_COINS_VIEW_ARGS_H
+#ifndef ADONAI_NODE_COINS_VIEW_ARGS_H
+#define ADONAI_NODE_COINS_VIEW_ARGS_H
 
 class ArgsManager;
 struct CoinsViewOptions;
@@ -13,4 +13,4 @@ namespace node {
 void ReadCoinsViewArgs(const ArgsManager& args, CoinsViewOptions& options);
 } // namespace node
 
-#endif // BITCOIN_NODE_COINS_VIEW_ARGS_H
+#endif // ADONAI_NODE_COINS_VIEW_ARGS_H

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_CONNECTION_TYPES_H
-#define BITCOIN_NODE_CONNECTION_TYPES_H
+#ifndef ADONAI_NODE_CONNECTION_TYPES_H
+#define ADONAI_NODE_CONNECTION_TYPES_H
 
 #include <cstdint>
 #include <string>
@@ -15,7 +15,7 @@
  *
  * If adding or removing types, please update CONNECTION_TYPE_DOC in
  * src/rpc/net.cpp and src/qt/rpcconsole.cpp, as well as the descriptions in
- * src/qt/guiutil.cpp and src/bitcoin-cli.cpp::NetinfoRequestHandler. */
+ * src/qt/guiutil.cpp and src/adonai-cli.cpp::NetinfoRequestHandler. */
 enum class ConnectionType {
     /**
      * Inbound connections are those initiated by a peer. This is the only
@@ -49,7 +49,7 @@ enum class ConnectionType {
      *   evict only if this longer-known peer is offline.
      * - move node addresses from New to Tried table, so that we have more
      *   connectable addresses in our AddrMan.
-     * Note that in the literature ("Eclipse Attacks on Bitcoin’s Peer-to-Peer Network")
+     * Note that in the literature ("Eclipse Attacks on Adonai’s Peer-to-Peer Network")
      * only the latter feature is referred to as "feeler connections",
      * although in our codebase feeler connections encompass test-before-evict as well.
      * We make these connections approximately every FEELER_INTERVAL:
@@ -91,4 +91,4 @@ enum class TransportProtocolType : uint8_t {
 /** Convert TransportProtocolType enum to a string value */
 std::string TransportTypeAsString(TransportProtocolType transport_type);
 
-#endif // BITCOIN_NODE_CONNECTION_TYPES_H
+#endif // ADONAI_NODE_CONNECTION_TYPES_H

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_CONTEXT_H
-#define BITCOIN_NODE_CONTEXT_H
+#ifndef ADONAI_NODE_CONTEXT_H
+#define ADONAI_NODE_CONTEXT_H
 
 #include <atomic>
 #include <cstdlib>
@@ -55,7 +55,7 @@ class Warnings;
 //! any member functions. It should just be a collection of references that can
 //! be used without pulling in unwanted dependencies or functionality.
 struct NodeContext {
-    //! libbitcoin_kernel context
+    //! libadonai_kernel context
     std::unique_ptr<kernel::Context> kernel;
     std::unique_ptr<ECC_Context> ecc_context;
     //! Init interface for initializing current process and connecting to other processes.
@@ -100,4 +100,4 @@ struct NodeContext {
 };
 } // namespace node
 
-#endif // BITCOIN_NODE_CONTEXT_H
+#endif // ADONAI_NODE_CONTEXT_H

--- a/src/node/database_args.h
+++ b/src/node/database_args.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_DATABASE_ARGS_H
-#define BITCOIN_NODE_DATABASE_ARGS_H
+#ifndef ADONAI_NODE_DATABASE_ARGS_H
+#define ADONAI_NODE_DATABASE_ARGS_H
 
 class ArgsManager;
 struct DBOptions;
@@ -13,4 +13,4 @@ namespace node {
 void ReadDatabaseArgs(const ArgsManager& args, DBOptions& options);
 } // namespace node
 
-#endif // BITCOIN_NODE_DATABASE_ARGS_H
+#endif // ADONAI_NODE_DATABASE_ARGS_H

--- a/src/node/eviction.h
+++ b/src/node/eviction.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_EVICTION_H
-#define BITCOIN_NODE_EVICTION_H
+#ifndef ADONAI_NODE_EVICTION_H
+#define ADONAI_NODE_EVICTION_H
 
 #include <node/connection_types.h>
 #include <net_permissions.h>
@@ -67,4 +67,4 @@ struct NodeEvictionCandidate {
  */
 void ProtectEvictionCandidatesByRatio(std::vector<NodeEvictionCandidate>& vEvictionCandidates);
 
-#endif // BITCOIN_NODE_EVICTION_H
+#endif // ADONAI_NODE_EVICTION_H

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_INTERFACE_UI_H
-#define BITCOIN_NODE_INTERFACE_UI_H
+#ifndef ADONAI_NODE_INTERFACE_UI_H
+#define ADONAI_NODE_INTERFACE_UI_H
 
 #include <cstdint>
 #include <functional>
@@ -122,4 +122,4 @@ bool InitError(const bilingual_str& str, const std::vector<std::string>& details
 
 extern CClientUIInterface uiInterface;
 
-#endif // BITCOIN_NODE_INTERFACE_UI_H
+#endif // ADONAI_NODE_INTERFACE_UI_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -63,7 +63,7 @@
 #include <validation.h>
 #include <validationinterface.h>
 
-#include <bitcoin-build-config.h> // IWYU pragma: keep
+#include <adonai-build-config.h> // IWYU pragma: keep
 
 #include <any>
 #include <memory>

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -5,7 +5,7 @@
 
 #include <node/kernel_notifications.h>
 
-#include <bitcoin-build-config.h> // IWYU pragma: keep
+#include <adonai-build-config.h> // IWYU pragma: keep
 
 #include <chain.h>
 #include <common/args.h>

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_KERNEL_NOTIFICATIONS_H
-#define BITCOIN_NODE_KERNEL_NOTIFICATIONS_H
+#ifndef ADONAI_NODE_KERNEL_NOTIFICATIONS_H
+#define ADONAI_NODE_KERNEL_NOTIFICATIONS_H
 
 #include <kernel/notifications_interface.h>
 
@@ -74,4 +74,4 @@ void ReadNotificationArgs(const ArgsManager& args, KernelNotifications& notifica
 
 } // namespace node
 
-#endif // BITCOIN_NODE_KERNEL_NOTIFICATIONS_H
+#endif // ADONAI_NODE_KERNEL_NOTIFICATIONS_H

--- a/src/node/mempool_args.h
+++ b/src/node/mempool_args.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_MEMPOOL_ARGS_H
-#define BITCOIN_NODE_MEMPOOL_ARGS_H
+#ifndef ADONAI_NODE_MEMPOOL_ARGS_H
+#define ADONAI_NODE_MEMPOOL_ARGS_H
 
 #include <util/result.h>
 
@@ -25,4 +25,4 @@ struct MemPoolOptions;
 [[nodiscard]] util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainParams& chainparams, kernel::MemPoolOptions& mempool_opts);
 
 
-#endif // BITCOIN_NODE_MEMPOOL_ARGS_H
+#endif // ADONAI_NODE_MEMPOOL_ARGS_H

--- a/src/node/mempool_persist.h
+++ b/src/node/mempool_persist.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_MEMPOOL_PERSIST_H
-#define BITCOIN_NODE_MEMPOOL_PERSIST_H
+#ifndef ADONAI_NODE_MEMPOOL_PERSIST_H
+#define ADONAI_NODE_MEMPOOL_PERSIST_H
 
 #include <util/fs.h>
 
@@ -32,4 +32,4 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path,
 } // namespace node
 
 
-#endif // BITCOIN_NODE_MEMPOOL_PERSIST_H
+#endif // ADONAI_NODE_MEMPOOL_PERSIST_H

--- a/src/node/mempool_persist_args.h
+++ b/src/node/mempool_persist_args.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_MEMPOOL_PERSIST_ARGS_H
-#define BITCOIN_NODE_MEMPOOL_PERSIST_ARGS_H
+#ifndef ADONAI_NODE_MEMPOOL_PERSIST_ARGS_H
+#define ADONAI_NODE_MEMPOOL_PERSIST_ARGS_H
 
 #include <util/fs.h>
 
@@ -23,4 +23,4 @@ fs::path MempoolPath(const ArgsManager& argsman);
 
 } // namespace node
 
-#endif // BITCOIN_NODE_MEMPOOL_PERSIST_ARGS_H
+#endif // ADONAI_NODE_MEMPOOL_PERSIST_ARGS_H

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_MINER_H
-#define BITCOIN_NODE_MINER_H
+#ifndef ADONAI_NODE_MINER_H
+#define ADONAI_NODE_MINER_H
 
 #include <interfaces/types.h>
 #include <node/types.h>
@@ -258,4 +258,4 @@ std::optional<BlockRef> GetTip(ChainstateManager& chainman);
 std::optional<BlockRef> WaitTipChanged(ChainstateManager& chainman, KernelNotifications& kernel_notifications, const uint256& current_tip, MillisecondsDouble& timeout);
 } // namespace node
 
-#endif // BITCOIN_NODE_MINER_H
+#endif // ADONAI_NODE_MINER_H

--- a/src/node/mini_miner.h
+++ b/src/node/mini_miner.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_MINI_MINER_H
-#define BITCOIN_NODE_MINI_MINER_H
+#ifndef ADONAI_NODE_MINI_MINER_H
+#define ADONAI_NODE_MINI_MINER_H
 
 #include <consensus/amount.h>
 #include <primitives/transaction.h>
@@ -170,4 +170,4 @@ public:
 };
 } // namespace node
 
-#endif // BITCOIN_NODE_MINI_MINER_H
+#endif // ADONAI_NODE_MINI_MINER_H

--- a/src/node/minisketchwrapper.h
+++ b/src/node/minisketchwrapper.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_MINISKETCHWRAPPER_H
-#define BITCOIN_NODE_MINISKETCHWRAPPER_H
+#ifndef ADONAI_NODE_MINISKETCHWRAPPER_H
+#define ADONAI_NODE_MINISKETCHWRAPPER_H
 
 #include <minisketch.h>
 
@@ -18,4 +18,4 @@ Minisketch MakeMinisketch32(size_t capacity);
 Minisketch MakeMinisketch32FP(size_t max_elements, uint32_t fpbits);
 } // namespace node
 
-#endif // BITCOIN_NODE_MINISKETCHWRAPPER_H
+#endif // ADONAI_NODE_MINISKETCHWRAPPER_H

--- a/src/node/peerman_args.h
+++ b/src/node/peerman_args.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/license/mit.
 
-#ifndef BITCOIN_NODE_PEERMAN_ARGS_H
-#define BITCOIN_NODE_PEERMAN_ARGS_H
+#ifndef ADONAI_NODE_PEERMAN_ARGS_H
+#define ADONAI_NODE_PEERMAN_ARGS_H
 
 #include <net_processing.h>
 
@@ -14,4 +14,4 @@ namespace node {
 void ApplyArgsManOptions(const ArgsManager& argsman, PeerManager::Options& options);
 } // namespace node
 
-#endif // BITCOIN_NODE_PEERMAN_ARGS_H
+#endif // ADONAI_NODE_PEERMAN_ARGS_H

--- a/src/node/protocol_version.h
+++ b/src/node/protocol_version.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_PROTOCOL_VERSION_H
-#define BITCOIN_NODE_PROTOCOL_VERSION_H
+#ifndef ADONAI_NODE_PROTOCOL_VERSION_H
+#define ADONAI_NODE_PROTOCOL_VERSION_H
 
 /**
  * network protocol versioning
@@ -36,4 +36,4 @@ static const int INVALID_CB_NO_BAN_VERSION = 70015;
 //! "wtxidrelay" command for wtxid-based relay starts with this version
 static const int WTXID_RELAY_VERSION = 70016;
 
-#endif // BITCOIN_NODE_PROTOCOL_VERSION_H
+#endif // ADONAI_NODE_PROTOCOL_VERSION_H

--- a/src/node/psbt.h
+++ b/src/node/psbt.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_PSBT_H
-#define BITCOIN_NODE_PSBT_H
+#ifndef ADONAI_NODE_PSBT_H
+#define ADONAI_NODE_PSBT_H
 
 #include <psbt.h>
 
@@ -56,4 +56,4 @@ struct PSBTAnalysis {
 PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx);
 } // namespace node
 
-#endif // BITCOIN_NODE_PSBT_H
+#endif // ADONAI_NODE_PSBT_H

--- a/src/node/timeoffsets.h
+++ b/src/node/timeoffsets.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_TIMEOFFSETS_H
-#define BITCOIN_NODE_TIMEOFFSETS_H
+#ifndef ADONAI_NODE_TIMEOFFSETS_H
+#define ADONAI_NODE_TIMEOFFSETS_H
 
 #include <sync.h>
 
@@ -47,4 +47,4 @@ public:
     bool WarnIfOutOfSync() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 };
 
-#endif // BITCOIN_NODE_TIMEOFFSETS_H
+#endif // ADONAI_NODE_TIMEOFFSETS_H

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_TRANSACTION_H
-#define BITCOIN_NODE_TRANSACTION_H
+#ifndef ADONAI_NODE_TRANSACTION_H
+#define ADONAI_NODE_TRANSACTION_H
 
 #include <common/messages.h>
 #include <policy/feerate.h>
@@ -67,4 +67,4 @@ static const CAmount DEFAULT_MAX_BURN_AMOUNT{0};
 CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, uint256& hashBlock, const BlockManager& blockman);
 } // namespace node
 
-#endif // BITCOIN_NODE_TRANSACTION_H
+#endif // ADONAI_NODE_TRANSACTION_H

--- a/src/node/txdownloadman.h
+++ b/src/node/txdownloadman.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_TXDOWNLOADMAN_H
-#define BITCOIN_NODE_TXDOWNLOADMAN_H
+#ifndef ADONAI_NODE_TXDOWNLOADMAN_H
+#define ADONAI_NODE_TXDOWNLOADMAN_H
 
 #include <net.h>
 #include <policy/packages.h>
@@ -177,4 +177,4 @@ public:
     std::vector<TxOrphanage::OrphanTxBase> GetOrphanTransactions() const;
 };
 } // namespace node
-#endif // BITCOIN_NODE_TXDOWNLOADMAN_H
+#endif // ADONAI_NODE_TXDOWNLOADMAN_H

--- a/src/node/txdownloadman_impl.h
+++ b/src/node/txdownloadman_impl.h
@@ -2,8 +2,8 @@
 // Modifications (c) 2025 The Adonai Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#ifndef BITCOIN_NODE_TXDOWNLOADMAN_IMPL_H
-#define BITCOIN_NODE_TXDOWNLOADMAN_IMPL_H
+#ifndef ADONAI_NODE_TXDOWNLOADMAN_IMPL_H
+#define ADONAI_NODE_TXDOWNLOADMAN_IMPL_H
 
 #include <node/txdownloadman.h>
 
@@ -202,4 +202,4 @@ protected:
     bool MaybeAddOrphanResolutionCandidate(const std::vector<Txid>& unique_parents, const Wtxid& wtxid, NodeId nodeid, std::chrono::microseconds now);
 };
 } // namespace node
-#endif // BITCOIN_NODE_TXDOWNLOADMAN_IMPL_H
+#endif // ADONAI_NODE_TXDOWNLOADMAN_IMPL_H

--- a/src/node/txreconciliation.h
+++ b/src/node/txreconciliation.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_TXRECONCILIATION_H
-#define BITCOIN_NODE_TXRECONCILIATION_H
+#ifndef ADONAI_NODE_TXRECONCILIATION_H
+#define ADONAI_NODE_TXRECONCILIATION_H
 
 #include <net.h>
 #include <sync.h>
@@ -87,4 +87,4 @@ public:
     bool IsPeerRegistered(NodeId peer_id) const;
 };
 
-#endif // BITCOIN_NODE_TXRECONCILIATION_H
+#endif // ADONAI_NODE_TXRECONCILIATION_H

--- a/src/node/types.h
+++ b/src/node/types.h
@@ -11,8 +11,8 @@
 //! dependencies. More complicated types should be defined in dedicated header
 //! files.
 
-#ifndef BITCOIN_NODE_TYPES_H
-#define BITCOIN_NODE_TYPES_H
+#ifndef ADONAI_NODE_TYPES_H
+#define ADONAI_NODE_TYPES_H
 
 #include <consensus/amount.h>
 #include <cstddef>
@@ -100,4 +100,4 @@ struct BlockCheckOptions {
 };
 } // namespace node
 
-#endif // BITCOIN_NODE_TYPES_H
+#endif // ADONAI_NODE_TYPES_H

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_UTXO_SNAPSHOT_H
-#define BITCOIN_NODE_UTXO_SNAPSHOT_H
+#ifndef ADONAI_NODE_UTXO_SNAPSHOT_H
+#define ADONAI_NODE_UTXO_SNAPSHOT_H
 
 #include <chainparams.h>
 #include <kernel/chainparams.h>
@@ -130,4 +130,4 @@ std::optional<fs::path> FindSnapshotChainstateDir(const fs::path& data_dir);
 
 } // namespace node
 
-#endif // BITCOIN_NODE_UTXO_SNAPSHOT_H
+#endif // ADONAI_NODE_UTXO_SNAPSHOT_H

--- a/src/node/warnings.cpp
+++ b/src/node/warnings.cpp
@@ -4,7 +4,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bitcoin-build-config.h> // IWYU pragma: keep
+#include <adonai-build-config.h> // IWYU pragma: keep
 
 #include <node/warnings.h>
 

--- a/src/node/warnings.h
+++ b/src/node/warnings.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_WARNINGS_H
-#define BITCOIN_NODE_WARNINGS_H
+#ifndef ADONAI_NODE_WARNINGS_H
+#define ADONAI_NODE_WARNINGS_H
 
 #include <sync.h>
 #include <util/translation.h>
@@ -88,4 +88,4 @@ public:
 UniValue GetWarningsForRpc(const Warnings& warnings, bool use_deprecated);
 } // namespace node
 
-#endif // BITCOIN_NODE_WARNINGS_H
+#endif // ADONAI_NODE_WARNINGS_H


### PR DESCRIPTION
## Summary
- rename Bitcoin/BTC references to Adonai/ADO across `src/node`
- update include guards and build-config include to match Adonai naming

## Testing
- `cmake -S . -B build -GNinja`
- `ninja -C build libbitcoin_node.a` *(fails: build interrupted by user)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c1e1dc58832dbf9ed08151bc8209