### PR TITLE
Fix build configuration header references

### DIFF
--- a/src/adonai-cli.cpp
+++ b/src/adonai-cli.cpp
@@ -82,7 +82,7 @@ static void SetupCliArgs(ArgsManager& argsman)
     const auto regtestBaseParams = CreateBaseChainParams(ChainType::REGTEST);
 
     argsman.AddArg("-version", "Print version and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", ADONAI_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::OPTIONS);
     argsman.AddArg("-generate",
                    strprintf("Generate blocks, equivalent to RPC getnewaddress followed by RPC generatetoaddress. Optional positional integer "

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -63,7 +63,7 @@
 #include <validation.h>
 #include <validationinterface.h>
 
-#include <adonai-build-config.h> // IWYU pragma: keep
+#include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <any>
 #include <memory>

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -5,7 +5,7 @@
 
 #include <node/kernel_notifications.h>
 
-#include <adonai-build-config.h> // IWYU pragma: keep
+#include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <chain.h>
 #include <common/args.h>

--- a/src/node/warnings.cpp
+++ b/src/node/warnings.cpp
@@ -4,7 +4,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <adonai-build-config.h> // IWYU pragma: keep
+#include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <node/warnings.h>
 


### PR DESCRIPTION
## Summary
- use existing BITCOIN_CONF_FILENAME constant in CLI
- include bitcoin-build-config.h in node sources

## Testing
- `cmake -S . -B build`
- `cmake --build build --target adonai_node -j$(nproc)` *(build interrupted after verifying compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c7142f20832dae47189fe7c2a68c