### PR TITLE
refactor: rename Bitcoin to Adonai in policy

### DIFF
--- a/src/policy/ephemeral_policy.h
+++ b/src/policy/ephemeral_policy.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_POLICY_EPHEMERAL_POLICY_H
-#define BITCOIN_POLICY_EPHEMERAL_POLICY_H
+#ifndef ADONAI_POLICY_EPHEMERAL_POLICY_H
+#define ADONAI_POLICY_EPHEMERAL_POLICY_H
 
 #include <consensus/amount.h>
 #include <policy/packages.h>
@@ -56,4 +56,4 @@ bool PreCheckEphemeralTx(const CTransaction& tx, CFeeRate dust_relay_rate, CAmou
  */
 bool CheckEphemeralSpends(const Package& package, CFeeRate dust_relay_rate, const CTxMemPool& tx_pool, TxValidationState& out_child_state, Wtxid& out_child_wtxid);
 
-#endif // BITCOIN_POLICY_EPHEMERAL_POLICY_H
+#endif // ADONAI_POLICY_EPHEMERAL_POLICY_H

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_POLICY_FEERATE_H
-#define BITCOIN_POLICY_FEERATE_H
+#ifndef ADONAI_POLICY_FEERATE_H
+#define ADONAI_POLICY_FEERATE_H
 
 #include <consensus/amount.h>
 #include <serialize.h>
@@ -15,7 +15,7 @@
 #include <string>
 #include <type_traits>
 
-const std::string CURRENCY_UNIT = "BTC"; // One formatted unit
+const std::string CURRENCY_UNIT = "ADO"; // One formatted unit
 const std::string CURRENCY_ATOM = "sat"; // One indivisible minimum value unit
 
 /* Used to determine type of fee estimation requested */
@@ -23,7 +23,7 @@ enum class FeeEstimateMode {
     UNSET,        //!< Use default settings based on other criteria
     ECONOMICAL,   //!< Force estimateSmartFee to use non-conservative estimates
     CONSERVATIVE, //!< Force estimateSmartFee to use conservative estimates
-    BTC_KVB,      //!< Use BTC/kvB fee rate unit
+    ADO_KVB,      //!< Use ADO/kvB fee rate unit
     SAT_VB,       //!< Use sat/vB fee rate unit
 };
 
@@ -69,11 +69,11 @@ public:
     friend bool operator>=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK >= b.nSatoshisPerK; }
     friend bool operator!=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK != b.nSatoshisPerK; }
     CFeeRate& operator+=(const CFeeRate& a) { nSatoshisPerK += a.nSatoshisPerK; return *this; }
-    std::string ToString(const FeeEstimateMode& fee_estimate_mode = FeeEstimateMode::BTC_KVB) const;
+    std::string ToString(const FeeEstimateMode& fee_estimate_mode = FeeEstimateMode::ADO_KVB) const;
     friend CFeeRate operator*(const CFeeRate& f, int a) { return CFeeRate(a * f.nSatoshisPerK); }
     friend CFeeRate operator*(int a, const CFeeRate& f) { return CFeeRate(a * f.nSatoshisPerK); }
 
     SERIALIZE_METHODS(CFeeRate, obj) { READWRITE(obj.nSatoshisPerK); }
 };
 
-#endif // BITCOIN_POLICY_FEERATE_H
+#endif // ADONAI_POLICY_FEERATE_H

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -627,7 +627,7 @@ void CBlockPolicyEstimator::processTransaction(const NewMempoolTransactionInfo& 
     }
     trackedTxs++;
 
-    // Feerates are stored and reported as BTC-per-kb:
+    // Feerates are stored and reported as ADO-per-kb:
     const CFeeRate feeRate(tx.info.m_fee, tx.info.m_virtual_transaction_size);
 
     mapMemPoolTxs[hash].blockHeight = txHeight;
@@ -658,7 +658,7 @@ bool CBlockPolicyEstimator::processBlockTx(unsigned int nBlockHeight, const Remo
         return false;
     }
 
-    // Feerates are stored and reported as BTC-per-kb:
+    // Feerates are stored and reported as ADO-per-kb:
     CFeeRate feeRate(tx.info.m_fee, tx.info.m_virtual_transaction_size);
 
     feeStats->Record(blocksToConfirm, static_cast<double>(feeRate.GetFeePerK()));

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -3,8 +3,8 @@
 // Modifications (c) 2025 The Adonai Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#ifndef BITCOIN_POLICY_FEES_H
-#define BITCOIN_POLICY_FEES_H
+#ifndef ADONAI_POLICY_FEES_H
+#define ADONAI_POLICY_FEES_H
 
 #include <consensus/amount.h>
 #include <policy/feerate.h>
@@ -343,4 +343,4 @@ private:
     FastRandomContext& insecure_rand GUARDED_BY(m_insecure_rand_mutex);
 };
 
-#endif // BITCOIN_POLICY_FEES_H
+#endif // ADONAI_POLICY_FEES_H

--- a/src/policy/fees_args.h
+++ b/src/policy/fees_args.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_POLICY_FEES_ARGS_H
-#define BITCOIN_POLICY_FEES_ARGS_H
+#ifndef ADONAI_POLICY_FEES_ARGS_H
+#define ADONAI_POLICY_FEES_ARGS_H
 
 #include <util/fs.h>
 
@@ -13,4 +13,4 @@ class ArgsManager;
 /** @return The fee estimates data file path. */
 fs::path FeeestPath(const ArgsManager& argsman);
 
-#endif // BITCOIN_POLICY_FEES_ARGS_H
+#endif // ADONAI_POLICY_FEES_ARGS_H

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_POLICY_PACKAGES_H
-#define BITCOIN_POLICY_PACKAGES_H
+#ifndef ADONAI_POLICY_PACKAGES_H
+#define ADONAI_POLICY_PACKAGES_H
 
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
@@ -95,4 +95,4 @@ bool IsChildWithParentsTree(const Package& package);
  */
 uint256 GetPackageHash(const std::vector<CTransactionRef>& transactions);
 
-#endif // BITCOIN_POLICY_PACKAGES_H
+#endif // ADONAI_POLICY_PACKAGES_H

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_POLICY_POLICY_H
-#define BITCOIN_POLICY_POLICY_H
+#ifndef ADONAI_POLICY_POLICY_H
+#define ADONAI_POLICY_POLICY_H
 
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
@@ -181,4 +181,4 @@ static inline int64_t GetVirtualTransactionInputSize(const CTxIn& tx)
     return GetVirtualTransactionInputSize(tx, 0, 0);
 }
 
-#endif // BITCOIN_POLICY_POLICY_H
+#endif // ADONAI_POLICY_POLICY_H

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_POLICY_RBF_H
-#define BITCOIN_POLICY_RBF_H
+#ifndef ADONAI_POLICY_RBF_H
+#define ADONAI_POLICY_RBF_H
 
 #include <consensus/amount.h>
 #include <primitives/transaction.h>
@@ -123,4 +123,4 @@ std::optional<std::string> PaysForRBF(CAmount original_fees,
  */
 std::optional<std::pair<DiagramCheckError, std::string>> ImprovesFeerateDiagram(CTxMemPool::ChangeSet& changeset);
 
-#endif // BITCOIN_POLICY_RBF_H
+#endif // ADONAI_POLICY_RBF_H

--- a/src/policy/settings.h
+++ b/src/policy/settings.h
@@ -4,9 +4,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_POLICY_SETTINGS_H
-#define BITCOIN_POLICY_SETTINGS_H
+#ifndef ADONAI_POLICY_SETTINGS_H
+#define ADONAI_POLICY_SETTINGS_H
 
 extern unsigned int nBytesPerSigOp;
 
-#endif // BITCOIN_POLICY_SETTINGS_H
+#endif // ADONAI_POLICY_SETTINGS_H

--- a/src/policy/truc_policy.h
+++ b/src/policy/truc_policy.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_POLICY_TRUC_POLICY_H
-#define BITCOIN_POLICY_TRUC_POLICY_H
+#ifndef ADONAI_POLICY_TRUC_POLICY_H
+#define ADONAI_POLICY_TRUC_POLICY_H
 
 #include <consensus/amount.h>
 #include <policy/packages.h>
@@ -92,4 +92,4 @@ std::optional<std::string> PackageTRUCChecks(const CTransactionRef& ptx, int64_t
                                            const Package& package,
                                            const CTxMemPool::setEntries& mempool_ancestors);
 
-#endif // BITCOIN_POLICY_TRUC_POLICY_H
+#endif // ADONAI_POLICY_TRUC_POLICY_H

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(BinaryOperatorTest)
     BOOST_CHECK(a <= a);
     BOOST_CHECK(b >= a);
     BOOST_CHECK(b >= b);
-    // a should be 0.00000002 BTC/kvB now
+    // a should be 0.00000002 ADO/kvB now
     a += a;
     BOOST_CHECK(a == b);
 }
@@ -135,8 +135,8 @@ BOOST_AUTO_TEST_CASE(ToStringTest)
 {
     CFeeRate feeRate;
     feeRate = CFeeRate(1);
-    BOOST_CHECK_EQUAL(feeRate.ToString(), "0.00000001 BTC/kvB");
-    BOOST_CHECK_EQUAL(feeRate.ToString(FeeEstimateMode::BTC_KVB), "0.00000001 BTC/kvB");
+    BOOST_CHECK_EQUAL(feeRate.ToString(), "0.00000001 ADO/kvB");
+    BOOST_CHECK_EQUAL(feeRate.ToString(FeeEstimateMode::ADO_KVB), "0.00000001 ADO/kvB");
     BOOST_CHECK_EQUAL(feeRate.ToString(FeeEstimateMode::SAT_VB), "0.001 sat/vB");
 }
 


### PR DESCRIPTION
## Summary
- refactor policy headers and constants from Bitcoin/BTC to Adonai/ADO
- update fee rate formatting and related tests

## Testing
- `cmake -S . -B build -GNinja` *(failed: initially Boost missing, installed, then configured)*
- `cmake --build build --target test_bitcoin -j2` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c482ce18832d95d3380e1e033dff