### PR TITLE
refactor: rename logging include guard for Adonai

### DIFF
--- a/src/logging/timer.h
+++ b/src/logging/timer.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_LOGGING_TIMER_H
-#define BITCOIN_LOGGING_TIMER_H
+#ifndef ADONAI_LOGGING_TIMER_H
+#define ADONAI_LOGGING_TIMER_H
 
 #include <logging.h>
 #include <util/macros.h>
@@ -109,4 +109,4 @@ private:
     BCLog::Timer<std::chrono::seconds> UNIQUE_NAME(logging_timer)(__func__, end_msg)
 
 
-#endif // BITCOIN_LOGGING_TIMER_H
+#endif // ADONAI_LOGGING_TIMER_H


### PR DESCRIPTION
## Summary
- rename logging timer include guard from BITCOIN to ADONAI

## Testing
- `cmake -S . -B build` *(fails: Could not find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_68b2de2f1f08832dad224e0dbb7828b0