### PR TITLE
refactor: rename bitcoin references in kernel to adonai

### DIFF
--- a/src/kernel/blockmanager_opts.h
+++ b/src/kernel/blockmanager_opts.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_BLOCKMANAGER_OPTS_H
-#define BITCOIN_KERNEL_BLOCKMANAGER_OPTS_H
+#ifndef ADONAI_KERNEL_BLOCKMANAGER_OPTS_H
+#define ADONAI_KERNEL_BLOCKMANAGER_OPTS_H
 
 #include <dbwrapper.h>
 #include <kernel/notifications_interface.h>
@@ -34,4 +34,4 @@ struct BlockManagerOpts {
 
 } // namespace kernel
 
-#endif // BITCOIN_KERNEL_BLOCKMANAGER_OPTS_H
+#endif // ADONAI_KERNEL_BLOCKMANAGER_OPTS_H

--- a/src/kernel/caches.h
+++ b/src/kernel/caches.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_CACHES_H
-#define BITCOIN_KERNEL_CACHES_H
+#ifndef ADONAI_KERNEL_CACHES_H
+#define ADONAI_KERNEL_CACHES_H
 
 #include <util/byte_units.h>
 
@@ -34,4 +34,4 @@ struct CacheSizes {
 };
 } // namespace kernel
 
-#endif // BITCOIN_KERNEL_CACHES_H
+#endif // ADONAI_KERNEL_CACHES_H

--- a/src/kernel/chain.h
+++ b/src/kernel/chain.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_CHAIN_H
-#define BITCOIN_KERNEL_CHAIN_H
+#ifndef ADONAI_KERNEL_CHAIN_H
+#define ADONAI_KERNEL_CHAIN_H
 
 #include<iostream>
 
@@ -37,4 +37,4 @@ enum class ChainstateRole {
 
 std::ostream& operator<<(std::ostream& os, const ChainstateRole& role);
 
-#endif // BITCOIN_KERNEL_CHAIN_H
+#endif // ADONAI_KERNEL_CHAIN_H

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -433,7 +433,7 @@ public:
         vFixedSeeds.clear();
         vSeeds.clear();
         // nodes with support for servicebits filtering should be at the top
-        vSeeds.emplace_back("seed.testnet4.bitcoin.sprovoost.nl."); // Sjors Provoost
+        vSeeds.emplace_back("seed.testnet4.adonai.sprovoost.nl."); // Sjors Provoost
         vSeeds.emplace_back("seed.testnet4.wiz.biz."); // Jason Maurice
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
@@ -479,7 +479,7 @@ public:
             // Ejemplo de placeholder BIP325 (REEMPLAZA por tu clave):
             // 51 <33-byte pubkey> 51 AE   => OP_1 <PK> OP_1 OP_CHECKMULTISIG
             challenge_bin = "512103aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa51ae"_hex_v_u8; // TODO: reemplazar pubkey
-            // Sin seeds externos de Bitcoin
+            // Sin seeds externos de Adonai
             vFixedSeeds = {}; // TODO: añadir fijos propios si quieres
             // vSeeds.emplace_back("seed.signet.adonai.network."); // TODO: tus DNS seeds
         } else {
@@ -503,7 +503,7 @@ public:
         consensus.SegwitHeight = 1;
 
         // Timing objetivo ADONAI (mantén 60s si es tu target)
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // 2 semanas (estilo BTC; OK para tests)
+        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // 2 semanas (estilo ADO; OK para tests)
         consensus.nPowTargetSpacing  = 60;                // 60 s (ADONAI)
         consensus.fPowAllowMinDifficultyBlocks = true;    // facilita el arranque de signet
         consensus.fPowNoRetargeting = false;
@@ -542,7 +542,7 @@ public:
         std::copy_n(challenge_hash.begin(), 4, pchMessageStart.begin());
 
         // ----- RED -----
-        nDefaultPort = 28837;     // ADONAI signet P2P (evitar 38333 de BTC)
+        nDefaultPort = 28837;     // ADONAI signet P2P (evitar 38333 de ADO)
         nPruneAfterHeight = 1000;
 
         // ----- GENESIS (valores provisionales) -----
@@ -576,7 +576,7 @@ public:
         };
 
         // ----- ADDRESS PREFIXES -----
-        // Base58 (not critical if using Bech32; use values that don't collide with BTC):
+        // Base58 (not critical if using Bech32; use values that don't collide with ADO):
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 65);  // 'A' (~ADO signet)
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 125);
         base58Prefixes[SECRET_KEY]     = std::vector<unsigned char>(1, 153);

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_CHAINPARAMS_H
-#define BITCOIN_KERNEL_CHAINPARAMS_H
+#ifndef ADONAI_KERNEL_CHAINPARAMS_H
+#define ADONAI_KERNEL_CHAINPARAMS_H
 
 #include <consensus/params.h>
 #include <kernel/messagestartchars.h>
@@ -64,7 +64,7 @@ struct ChainTxData {
 
 /**
  * CChainParams defines various tweakable parameters of a given instance of the
- * Bitcoin system.
+ * Adonai system.
  */
 class CChainParams
 {
@@ -175,4 +175,4 @@ protected:
 
 std::optional<ChainType> GetNetworkForMagic(const MessageStartChars& pchMessageStart);
 
-#endif // BITCOIN_KERNEL_CHAINPARAMS_H
+#endif // ADONAI_KERNEL_CHAINPARAMS_H

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_CHAINSTATEMANAGER_OPTS_H
-#define BITCOIN_KERNEL_CHAINSTATEMANAGER_OPTS_H
+#ifndef ADONAI_KERNEL_CHAINSTATEMANAGER_OPTS_H
+#define ADONAI_KERNEL_CHAINSTATEMANAGER_OPTS_H
 
 #include <kernel/notifications_interface.h>
 
@@ -53,4 +53,4 @@ struct ChainstateManagerOpts {
 
 } // namespace kernel
 
-#endif // BITCOIN_KERNEL_CHAINSTATEMANAGER_OPTS_H
+#endif // ADONAI_KERNEL_CHAINSTATEMANAGER_OPTS_H

--- a/src/kernel/checks.h
+++ b/src/kernel/checks.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_CHECKS_H
-#define BITCOIN_KERNEL_CHECKS_H
+#ifndef ADONAI_KERNEL_CHECKS_H
+#define ADONAI_KERNEL_CHECKS_H
 
 #include <util/result.h>
 
@@ -18,4 +18,4 @@ struct Context;
 [[nodiscard]] util::Result<void> SanityChecks(const Context&);
 } // namespace kernel
 
-#endif // BITCOIN_KERNEL_CHECKS_H
+#endif // ADONAI_KERNEL_CHECKS_H

--- a/src/kernel/coinstats.h
+++ b/src/kernel/coinstats.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_COINSTATS_H
-#define BITCOIN_KERNEL_COINSTATS_H
+#ifndef ADONAI_KERNEL_COINSTATS_H
+#define ADONAI_KERNEL_COINSTATS_H
 
 #include <consensus/amount.h>
 #include <crypto/muhash.h>
@@ -80,4 +80,4 @@ void RemoveCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& c
 std::optional<CCoinsStats> ComputeUTXOStats(CoinStatsHashType hash_type, CCoinsView* view, node::BlockManager& blockman, const std::function<void()>& interruption_point = {});
 } // namespace kernel
 
-#endif // BITCOIN_KERNEL_COINSTATS_H
+#endif // ADONAI_KERNEL_COINSTATS_H

--- a/src/kernel/context.h
+++ b/src/kernel/context.h
@@ -3,12 +3,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_CONTEXT_H
-#define BITCOIN_KERNEL_CONTEXT_H
+#ifndef ADONAI_KERNEL_CONTEXT_H
+#define ADONAI_KERNEL_CONTEXT_H
 
 namespace kernel {
 //! Context struct holding the kernel library's logically global state, and
-//! passed to external libbitcoin_kernel functions which need access to this
+//! passed to external libadonai_kernel functions which need access to this
 //! state. The kernel library API is a work in progress, so state organization
 //! and member list will evolve over time.
 //!
@@ -19,4 +19,4 @@ struct Context {
 };
 } // namespace kernel
 
-#endif // BITCOIN_KERNEL_CONTEXT_H
+#endif // ADONAI_KERNEL_CONTEXT_H

--- a/src/kernel/cs_main.h
+++ b/src/kernel/cs_main.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_CS_MAIN_H
-#define BITCOIN_KERNEL_CS_MAIN_H
+#ifndef ADONAI_KERNEL_CS_MAIN_H
+#define ADONAI_KERNEL_CS_MAIN_H
 
 #include <sync.h>
 
@@ -20,4 +20,4 @@
  */
 extern RecursiveMutex cs_main;
 
-#endif // BITCOIN_KERNEL_CS_MAIN_H
+#endif // ADONAI_KERNEL_CS_MAIN_H

--- a/src/kernel/disconnected_transactions.h
+++ b/src/kernel/disconnected_transactions.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_DISCONNECTED_TRANSACTIONS_H
-#define BITCOIN_KERNEL_DISCONNECTED_TRANSACTIONS_H
+#ifndef ADONAI_KERNEL_DISCONNECTED_TRANSACTIONS_H
+#define ADONAI_KERNEL_DISCONNECTED_TRANSACTIONS_H
 
 #include <primitives/transaction.h>
 #include <util/hasher.h>
@@ -74,4 +74,4 @@ public:
     /** Clear all data structures and return the list of transactions. */
     std::list<CTransactionRef> take();
 };
-#endif // BITCOIN_KERNEL_DISCONNECTED_TRANSACTIONS_H
+#endif // ADONAI_KERNEL_DISCONNECTED_TRANSACTIONS_H

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_MEMPOOL_ENTRY_H
-#define BITCOIN_KERNEL_MEMPOOL_ENTRY_H
+#ifndef ADONAI_KERNEL_MEMPOOL_ENTRY_H
+#define ADONAI_KERNEL_MEMPOOL_ENTRY_H
 
 #include <consensus/amount.h>
 #include <consensus/validation.h>
@@ -250,4 +250,4 @@ struct NewMempoolTransactionInfo {
           m_has_no_mempool_parents{has_no_mempool_parents} {}
 };
 
-#endif // BITCOIN_KERNEL_MEMPOOL_ENTRY_H
+#endif // ADONAI_KERNEL_MEMPOOL_ENTRY_H

--- a/src/kernel/mempool_limits.h
+++ b/src/kernel/mempool_limits.h
@@ -2,8 +2,8 @@
 // Modifications (c) 2025 The Adonai Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#ifndef BITCOIN_KERNEL_MEMPOOL_LIMITS_H
-#define BITCOIN_KERNEL_MEMPOOL_LIMITS_H
+#ifndef ADONAI_KERNEL_MEMPOOL_LIMITS_H
+#define ADONAI_KERNEL_MEMPOOL_LIMITS_H
 
 #include <policy/policy.h>
 
@@ -37,4 +37,4 @@ struct MemPoolLimits {
 };
 } // namespace kernel
 
-#endif // BITCOIN_KERNEL_MEMPOOL_LIMITS_H
+#endif // ADONAI_KERNEL_MEMPOOL_LIMITS_H

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -2,8 +2,8 @@
 // Modifications (c) 2025 The Adonai Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#ifndef BITCOIN_KERNEL_MEMPOOL_OPTIONS_H
-#define BITCOIN_KERNEL_MEMPOOL_OPTIONS_H
+#ifndef ADONAI_KERNEL_MEMPOOL_OPTIONS_H
+#define ADONAI_KERNEL_MEMPOOL_OPTIONS_H
 
 #include <kernel/mempool_limits.h>
 
@@ -61,4 +61,4 @@ struct MemPoolOptions {
 };
 } // namespace kernel
 
-#endif // BITCOIN_KERNEL_MEMPOOL_OPTIONS_H
+#endif // ADONAI_KERNEL_MEMPOOL_OPTIONS_H

--- a/src/kernel/mempool_removal_reason.h
+++ b/src/kernel/mempool_removal_reason.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/license/mit/.
 
-#ifndef BITCOIN_KERNEL_MEMPOOL_REMOVAL_REASON_H
-#define BITCOIN_KERNEL_MEMPOOL_REMOVAL_REASON_H
+#ifndef ADONAI_KERNEL_MEMPOOL_REMOVAL_REASON_H
+#define ADONAI_KERNEL_MEMPOOL_REMOVAL_REASON_H
 
 #include <string>
 
@@ -22,4 +22,4 @@ enum class MemPoolRemovalReason {
 
 std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
 
-#endif // BITCOIN_KERNEL_MEMPOOL_REMOVAL_REASON_H
+#endif // ADONAI_KERNEL_MEMPOOL_REMOVAL_REASON_H

--- a/src/kernel/messagestartchars.h
+++ b/src/kernel/messagestartchars.h
@@ -3,12 +3,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_MESSAGESTARTCHARS_H
-#define BITCOIN_KERNEL_MESSAGESTARTCHARS_H
+#ifndef ADONAI_KERNEL_MESSAGESTARTCHARS_H
+#define ADONAI_KERNEL_MESSAGESTARTCHARS_H
 
 #include <array>
 #include <cstdint>
 
 using MessageStartChars = std::array<uint8_t, 4>;
 
-#endif // BITCOIN_KERNEL_MESSAGESTARTCHARS_H
+#endif // ADONAI_KERNEL_MESSAGESTARTCHARS_H

--- a/src/kernel/notifications_interface.h
+++ b/src/kernel/notifications_interface.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_NOTIFICATIONS_INTERFACE_H
-#define BITCOIN_KERNEL_NOTIFICATIONS_INTERFACE_H
+#ifndef ADONAI_KERNEL_NOTIFICATIONS_INTERFACE_H
+#define ADONAI_KERNEL_NOTIFICATIONS_INTERFACE_H
 
 #include <cstdint>
 #include <variant>
@@ -63,4 +63,4 @@ public:
 };
 } // namespace kernel
 
-#endif // BITCOIN_KERNEL_NOTIFICATIONS_INTERFACE_H
+#endif // ADONAI_KERNEL_NOTIFICATIONS_INTERFACE_H

--- a/src/kernel/warning.h
+++ b/src/kernel/warning.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_WARNING_H
-#define BITCOIN_KERNEL_WARNING_H
+#ifndef ADONAI_KERNEL_WARNING_H
+#define ADONAI_KERNEL_WARNING_H
 
 namespace kernel {
 enum class Warning {
@@ -12,4 +12,4 @@ enum class Warning {
     LARGE_WORK_INVALID_CHAIN,
 };
 } // namespace kernel
-#endif // BITCOIN_KERNEL_WARNING_H
+#endif // ADONAI_KERNEL_WARNING_H


### PR DESCRIPTION
## Summary
- replace bitcoin/btc identifiers with adonai/ado across kernel headers and chain parameters
- update kernel context to reference libadonai_kernel and adjust comments
- fix chain parameter seeds and comments to use Adonai terminology

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Boost" (requested version 1.73.0))*

------
https://chatgpt.com/codex/tasks/task_e_68b2de4e173c832db423eb5583caf7d1