### PR TITLE
Fix wallet build to use adonai common library

### DIFF
--- a/src/common/types.h
+++ b/src/common/types.h
@@ -4,15 +4,15 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 //! @file common/types.h is a home for simple enum and struct type definitions
-//! that can be used internally by functions in the libbitcoin_common library,
+//! that can be used internally by functions in the libadonai_common library,
 //! but also used externally by node, wallet, and GUI code.
 //!
 //! This file is intended to define only simple types that do not have external
 //! dependencies. More complicated types should be defined in dedicated header
 //! files.
 
-#ifndef BITCOIN_COMMON_TYPES_H
-#define BITCOIN_COMMON_TYPES_H
+#ifndef ADONAI_COMMON_TYPES_H
+#define ADONAI_COMMON_TYPES_H
 
 namespace common {
 enum class PSBTError {
@@ -26,4 +26,4 @@ enum class PSBTError {
 };
 } // namespace common
 
-#endif // BITCOIN_COMMON_TYPES_H
+#endif // ADONAI_COMMON_TYPES_H

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(adonai_wallet STATIC EXCLUDE_FROM_ALL
 target_link_libraries(adonai_wallet
   PRIVATE
     core_interface
-    bitcoin_common
+    adonai_common
     $<TARGET_NAME_IF_EXISTS:unofficial::sqlite3::sqlite3>
     $<TARGET_NAME_IF_EXISTS:SQLite::SQLite3>
     univalue


### PR DESCRIPTION
## Summary
- link adonai wallet library against adonai_common instead of missing bitcoin_common
- update common types header to use adonai naming

## Testing
- `cmake --build build --target adonai-wallet -j$(nproc)`
- `cmake --build build --target test_adonai -j$(nproc)` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e439c71c832d8159a5dabea46792