### PR TITLE
refactor: rename crypto header guards for Adonai

### DIFF
--- a/src/crypto/aes.h
+++ b/src/crypto/aes.h
@@ -5,8 +5,8 @@
 //
 // C++ wrapper around ctaes, a constant-time AES implementation
 
-#ifndef BITCOIN_CRYPTO_AES_H
-#define BITCOIN_CRYPTO_AES_H
+#ifndef ADONAI_CRYPTO_AES_H
+#define ADONAI_CRYPTO_AES_H
 
 extern "C" {
 #include <crypto/ctaes/ctaes.h>
@@ -65,4 +65,4 @@ private:
     unsigned char iv[AES_BLOCKSIZE];
 };
 
-#endif // BITCOIN_CRYPTO_AES_H
+#endif // ADONAI_CRYPTO_AES_H

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_CHACHA20_H
-#define BITCOIN_CRYPTO_CHACHA20_H
+#ifndef ADONAI_CRYPTO_CHACHA20_H
+#define ADONAI_CRYPTO_CHACHA20_H
 
 #include <span.h>
 
@@ -157,4 +157,4 @@ public:
     void Crypt(std::span<const std::byte> input, std::span<std::byte> output) noexcept;
 };
 
-#endif // BITCOIN_CRYPTO_CHACHA20_H
+#endif // ADONAI_CRYPTO_CHACHA20_H

--- a/src/crypto/chacha20poly1305.h
+++ b/src/crypto/chacha20poly1305.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_CHACHA20POLY1305_H
-#define BITCOIN_CRYPTO_CHACHA20POLY1305_H
+#ifndef ADONAI_CRYPTO_CHACHA20POLY1305_H
+#define ADONAI_CRYPTO_CHACHA20POLY1305_H
 
 #include <cstddef>
 #include <cstdint>
@@ -146,4 +146,4 @@ public:
     bool Decrypt(std::span<const std::byte> cipher, std::span<const std::byte> aad, std::span<std::byte> plain1, std::span<std::byte> plain2) noexcept;
 };
 
-#endif // BITCOIN_CRYPTO_CHACHA20POLY1305_H
+#endif // ADONAI_CRYPTO_CHACHA20POLY1305_H

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_COMMON_H
-#define BITCOIN_CRYPTO_COMMON_H
+#ifndef ADONAI_CRYPTO_COMMON_H
+#define ADONAI_CRYPTO_COMMON_H
 
 #include <compat/endian.h>
 
@@ -106,4 +106,4 @@ inline void WriteBE64(B* ptr, uint64_t x)
     memcpy(ptr, &v, 8);
 }
 
-#endif // BITCOIN_CRYPTO_COMMON_H
+#endif // ADONAI_CRYPTO_COMMON_H

--- a/src/crypto/hex_base.h
+++ b/src/crypto/hex_base.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_HEX_BASE_H
-#define BITCOIN_CRYPTO_HEX_BASE_H
+#ifndef ADONAI_CRYPTO_HEX_BASE_H
+#define ADONAI_CRYPTO_HEX_BASE_H
 
 #include <span.h>
 
@@ -21,4 +21,4 @@ inline std::string HexStr(const std::span<const std::byte> s) { return HexStr(Ma
 
 signed char HexDigit(char c);
 
-#endif // BITCOIN_CRYPTO_HEX_BASE_H
+#endif // ADONAI_CRYPTO_HEX_BASE_H

--- a/src/crypto/hkdf_sha256_32.h
+++ b/src/crypto/hkdf_sha256_32.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_HKDF_SHA256_32_H
-#define BITCOIN_CRYPTO_HKDF_SHA256_32_H
+#ifndef ADONAI_CRYPTO_HKDF_SHA256_32_H
+#define ADONAI_CRYPTO_HKDF_SHA256_32_H
 
 #include <crypto/hmac_sha256.h>
 
@@ -23,4 +23,4 @@ public:
     void Expand32(const std::string& info, unsigned char hash[OUTPUT_SIZE]);
 };
 
-#endif // BITCOIN_CRYPTO_HKDF_SHA256_32_H
+#endif // ADONAI_CRYPTO_HKDF_SHA256_32_H

--- a/src/crypto/hmac_sha256.h
+++ b/src/crypto/hmac_sha256.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_HMAC_SHA256_H
-#define BITCOIN_CRYPTO_HMAC_SHA256_H
+#ifndef ADONAI_CRYPTO_HMAC_SHA256_H
+#define ADONAI_CRYPTO_HMAC_SHA256_H
 
 #include <crypto/sha256.h>
 
@@ -30,4 +30,4 @@ public:
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
 };
 
-#endif // BITCOIN_CRYPTO_HMAC_SHA256_H
+#endif // ADONAI_CRYPTO_HMAC_SHA256_H

--- a/src/crypto/hmac_sha512.h
+++ b/src/crypto/hmac_sha512.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_HMAC_SHA512_H
-#define BITCOIN_CRYPTO_HMAC_SHA512_H
+#ifndef ADONAI_CRYPTO_HMAC_SHA512_H
+#define ADONAI_CRYPTO_HMAC_SHA512_H
 
 #include <crypto/sha512.h>
 
@@ -30,4 +30,4 @@ public:
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
 };
 
-#endif // BITCOIN_CRYPTO_HMAC_SHA512_H
+#endif // ADONAI_CRYPTO_HMAC_SHA512_H

--- a/src/crypto/muhash.h
+++ b/src/crypto/muhash.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_MUHASH_H
-#define BITCOIN_CRYPTO_MUHASH_H
+#ifndef ADONAI_CRYPTO_MUHASH_H
+#define ADONAI_CRYPTO_MUHASH_H
 
 #include <serialize.h>
 #include <uint256.h>
@@ -134,4 +134,4 @@ public:
     }
 };
 
-#endif // BITCOIN_CRYPTO_MUHASH_H
+#endif // ADONAI_CRYPTO_MUHASH_H

--- a/src/crypto/poly1305.h
+++ b/src/crypto/poly1305.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_POLY1305_H
-#define BITCOIN_CRYPTO_POLY1305_H
+#ifndef ADONAI_CRYPTO_POLY1305_H
+#define ADONAI_CRYPTO_POLY1305_H
 
 #include <span.h>
 
@@ -68,4 +68,4 @@ public:
     }
 };
 
-#endif // BITCOIN_CRYPTO_POLY1305_H
+#endif // ADONAI_CRYPTO_POLY1305_H

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_RIPEMD160_H
-#define BITCOIN_CRYPTO_RIPEMD160_H
+#ifndef ADONAI_CRYPTO_RIPEMD160_H
+#define ADONAI_CRYPTO_RIPEMD160_H
 
 #include <cstdint>
 #include <cstdlib>
@@ -26,4 +26,4 @@ public:
     CRIPEMD160& Reset();
 };
 
-#endif // BITCOIN_CRYPTO_RIPEMD160_H
+#endif // ADONAI_CRYPTO_RIPEMD160_H

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_SHA1_H
-#define BITCOIN_CRYPTO_SHA1_H
+#ifndef ADONAI_CRYPTO_SHA1_H
+#define ADONAI_CRYPTO_SHA1_H
 
 #include <cstdint>
 #include <cstdlib>
@@ -26,4 +26,4 @@ public:
     CSHA1& Reset();
 };
 
-#endif // BITCOIN_CRYPTO_SHA1_H
+#endif // ADONAI_CRYPTO_SHA1_H

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_SHA256_H
-#define BITCOIN_CRYPTO_SHA256_H
+#ifndef ADONAI_CRYPTO_SHA256_H
+#define ADONAI_CRYPTO_SHA256_H
 
 #include <cstdint>
 #include <cstdlib>
@@ -51,4 +51,4 @@ std::string SHA256AutoDetect(sha256_implementation::UseImplementation use_implem
  */
 void SHA256D64(unsigned char* output, const unsigned char* input, size_t blocks);
 
-#endif // BITCOIN_CRYPTO_SHA256_H
+#endif // ADONAI_CRYPTO_SHA256_H

--- a/src/crypto/sha3.h
+++ b/src/crypto/sha3.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_SHA3_H
-#define BITCOIN_CRYPTO_SHA3_H
+#ifndef ADONAI_CRYPTO_SHA3_H
+#define ADONAI_CRYPTO_SHA3_H
 
 #include <span.h>
 
@@ -39,4 +39,4 @@ public:
     SHA3_256& Reset();
 };
 
-#endif // BITCOIN_CRYPTO_SHA3_H
+#endif // ADONAI_CRYPTO_SHA3_H

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_SHA512_H
-#define BITCOIN_CRYPTO_SHA512_H
+#ifndef ADONAI_CRYPTO_SHA512_H
+#define ADONAI_CRYPTO_SHA512_H
 
 #include <cstdint>
 #include <cstdlib>
@@ -27,4 +27,4 @@ public:
     uint64_t Size() const { return bytes; }
 };
 
-#endif // BITCOIN_CRYPTO_SHA512_H
+#endif // ADONAI_CRYPTO_SHA512_H

--- a/src/crypto/siphash.h
+++ b/src/crypto/siphash.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_SIPHASH_H
-#define BITCOIN_CRYPTO_SIPHASH_H
+#ifndef ADONAI_CRYPTO_SIPHASH_H
+#define ADONAI_CRYPTO_SIPHASH_H
 
 #include <cstdint>
 
@@ -46,4 +46,4 @@ public:
 uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val);
 uint64_t SipHashUint256Extra(uint64_t k0, uint64_t k1, const uint256& val, uint32_t extra);
 
-#endif // BITCOIN_CRYPTO_SIPHASH_H
+#endif // ADONAI_CRYPTO_SIPHASH_H


### PR DESCRIPTION
## Summary
- replace BITCOIN_ prefixes in crypto header guards with ADONAI_

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Boost")*


------
https://chatgpt.com/codex/tasks/task_e_68b2e559844c832db6acc83faa269ed4