### PR TITLE
Remove line continuations in disabled AES test vectors

### DIFF
--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -601,31 +601,31 @@
 
 // BOOST_AUTO_TEST_CASE(aes_cbc_testvectors) {
 //     // NIST AES CBC 256-bit encryption test-vectors
-//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", \
-//                   "000102030405060708090A0B0C0D0E0F", false, "6bc1bee22e409f96e93d7e117393172a", \
+//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+//                   "000102030405060708090A0B0C0D0E0F", false, "6bc1bee22e409f96e93d7e117393172a",
 //                   "f58c4c04d6e5f1ba779eabfb5f7bfbd6");
-//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", \
-//                   "F58C4C04D6E5F1BA779EABFB5F7BFBD6", false, "ae2d8a571e03ac9c9eb76fac45af8e51", \
+//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+//                   "F58C4C04D6E5F1BA779EABFB5F7BFBD6", false, "ae2d8a571e03ac9c9eb76fac45af8e51",
 //                   "9cfc4e967edb808d679f777bc6702c7d");
-//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", \
+//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
 //                   "9CFC4E967EDB808D679F777BC6702C7D", false, "30c81c46a35ce411e5fbc1191a0a52ef",
 //                   "39f23369a9d9bacfa530e26304231461");
-//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", \
-//                   "39F23369A9D9BACFA530E26304231461", false, "f69f2445df4f9b17ad2b417be66c3710", \
+//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+//                   "39F23369A9D9BACFA530E26304231461", false, "f69f2445df4f9b17ad2b417be66c3710",
 //                   "b2eb05e2c39be9fcda6c19078c6a9d1b");
 
 //     // The same vectors with padding enabled
-//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", \
-//                   "000102030405060708090A0B0C0D0E0F", true, "6bc1bee22e409f96e93d7e117393172a", \
+//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+//                   "000102030405060708090A0B0C0D0E0F", true, "6bc1bee22e409f96e93d7e117393172a",
 //                   "f58c4c04d6e5f1ba779eabfb5f7bfbd6485a5c81519cf378fa36d42b8547edc0");
-//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", \
-//                   "F58C4C04D6E5F1BA779EABFB5F7BFBD6", true, "ae2d8a571e03ac9c9eb76fac45af8e51", \
+//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+//                   "F58C4C04D6E5F1BA779EABFB5F7BFBD6", true, "ae2d8a571e03ac9c9eb76fac45af8e51",
 //                   "9cfc4e967edb808d679f777bc6702c7d3a3aa5e0213db1a9901f9036cf5102d2");
-//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", \
+//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
 //                   "9CFC4E967EDB808D679F777BC6702C7D", true, "30c81c46a35ce411e5fbc1191a0a52ef",
 //                   "39f23369a9d9bacfa530e263042314612f8da707643c90a6f732b3de1d3f5cee");
-//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", \
-//                   "39F23369A9D9BACFA530E26304231461", true, "f69f2445df4f9b17ad2b417be66c3710", \
+//     TestAES256CBC("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+//                   "39F23369A9D9BACFA530E26304231461", true, "f69f2445df4f9b17ad2b417be66c3710",
 //                   "b2eb05e2c39be9fcda6c19078c6a9d1b3f461796d6b0d6b2e0c2a72b4d80e644");
 // }
 


### PR DESCRIPTION
## Summary
- drop stray backslashes from commented-out AES CBC test vectors to avoid multi-line comment warnings

## Testing
- `cmake -S . -B build`
- `cmake --build build --target test_adonai -j$(nproc)` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fc6275a8832dbd36f2f777ed11fa