### PR TITLE
Refactor consensus module to replace Bitcoin naming with Adonai

### DIFF
--- a/src/consensus/amount.h
+++ b/src/consensus/amount.h
@@ -4,15 +4,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CONSENSUS_AMOUNT_H
-#define BITCOIN_CONSENSUS_AMOUNT_H
+#ifndef ADONAI_CONSENSUS_AMOUNT_H
+#define ADONAI_CONSENSUS_AMOUNT_H
 
 #include <cstdint>
 
 /** Amount in satoshis (Can be negative) */
 typedef int64_t CAmount;
 
-/** The amount of satoshis in one BTC. */
+/** The amount of satoshis in one ADO. */
 static constexpr CAmount COIN = 100000000;
 
 /** No amount larger than this (in satoshi) is valid.
@@ -27,4 +27,4 @@ static constexpr CAmount COIN = 100000000;
 static constexpr CAmount MAX_MONEY = 280320000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
-#endif // BITCOIN_CONSENSUS_AMOUNT_H
+#endif // ADONAI_CONSENSUS_AMOUNT_H

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CONSENSUS_CONSENSUS_H
-#define BITCOIN_CONSENSUS_CONSENSUS_H
+#ifndef ADONAI_CONSENSUS_CONSENSUS_H
+#define ADONAI_CONSENSUS_CONSENSUS_H
 
 #include <cstdint>
 #include <cstdlib>
@@ -35,4 +35,4 @@ static constexpr unsigned int LOCKTIME_VERIFY_SEQUENCE = (1 << 0);
  */
 static constexpr int64_t MAX_TIMEWARP = 600;
 
-#endif // BITCOIN_CONSENSUS_CONSENSUS_H
+#endif // ADONAI_CONSENSUS_CONSENSUS_H

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -146,7 +146,7 @@ static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot
     bool matchh = matchlevel == level;
     while (count != ((uint32_t{1}) << level)) {
         // If we reach this point, h is an inner value that is not the top.
-        // We combine it with itself (Bitcoin's special rule for odd levels in
+        // We combine it with itself (Adonai's special rule for odd levels in
         // the tree) to produce a higher level one.
         if (path && matchh) {
             path->push_back(h);

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CONSENSUS_MERKLE_H
-#define BITCOIN_CONSENSUS_MERKLE_H
+#ifndef ADONAI_CONSENSUS_MERKLE_H
+#define ADONAI_CONSENSUS_MERKLE_H
 
 #include <vector>
 
@@ -35,4 +35,4 @@ uint256 BlockWitnessMerkleRoot(const CBlock& block, bool* mutated = nullptr);
  */
 std::vector<uint256> TransactionMerklePath(const CBlock& block, uint32_t position);
 
-#endif // BITCOIN_CONSENSUS_MERKLE_H
+#endif // ADONAI_CONSENSUS_MERKLE_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CONSENSUS_PARAMS_H
-#define BITCOIN_CONSENSUS_PARAMS_H
+#ifndef ADONAI_CONSENSUS_PARAMS_H
+#define ADONAI_CONSENSUS_PARAMS_H
 
 #include <uint256.h>
 
@@ -135,7 +135,7 @@ struct Params {
     uint256 defaultAssumeValid;
 
     /**
-     * If true, witness commitments contain a payload equal to a Bitcoin Script solution
+     * If true, witness commitments contain a payload equal to an Adonai Script solution
      * to the signet challenge. See BIP325.
      */
     bool signet_blocks{false};
@@ -161,4 +161,4 @@ struct Params {
 
 } // namespace Consensus
 
-#endif // BITCOIN_CONSENSUS_PARAMS_H
+#endif // ADONAI_CONSENSUS_PARAMS_H

--- a/src/consensus/tx_check.h
+++ b/src/consensus/tx_check.h
@@ -3,12 +3,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CONSENSUS_TX_CHECK_H
-#define BITCOIN_CONSENSUS_TX_CHECK_H
+#ifndef ADONAI_CONSENSUS_TX_CHECK_H
+#define ADONAI_CONSENSUS_TX_CHECK_H
 
 /**
  * Context-independent transaction checking code that can be called outside the
- * bitcoin server and doesn't depend on chain or mempool state. Transaction
+ * adonai server and doesn't depend on chain or mempool state. Transaction
  * verification code that does call server functions or depend on server state
  * belongs in tx_verify.h/cpp instead.
  */
@@ -18,4 +18,4 @@ class TxValidationState;
 
 bool CheckTransaction(const CTransaction& tx, TxValidationState& state);
 
-#endif // BITCOIN_CONSENSUS_TX_CHECK_H
+#endif // ADONAI_CONSENSUS_TX_CHECK_H

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CONSENSUS_TX_VERIFY_H
-#define BITCOIN_CONSENSUS_TX_VERIFY_H
+#ifndef ADONAI_CONSENSUS_TX_VERIFY_H
+#define ADONAI_CONSENSUS_TX_VERIFY_H
 
 #include <consensus/amount.h>
 
@@ -76,4 +76,4 @@ bool EvaluateSequenceLocks(const CBlockIndex& block, std::pair<int, int64_t> loc
  */
 bool SequenceLocks(const CTransaction &tx, int flags, std::vector<int>& prevHeights, const CBlockIndex& block);
 
-#endif // BITCOIN_CONSENSUS_TX_VERIFY_H
+#endif // ADONAI_CONSENSUS_TX_VERIFY_H

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CONSENSUS_VALIDATION_H
-#define BITCOIN_CONSENSUS_VALIDATION_H
+#ifndef ADONAI_CONSENSUS_VALIDATION_H
+#define ADONAI_CONSENSUS_VALIDATION_H
 
 #include <string>
 #include <consensus/consensus.h>
@@ -165,4 +165,4 @@ inline int GetWitnessCommitmentIndex(const CBlock& block)
     return commitpos;
 }
 
-#endif // BITCOIN_CONSENSUS_VALIDATION_H
+#endif // ADONAI_CONSENSUS_VALIDATION_H


### PR DESCRIPTION
## Summary
- rename consensus include guards from BITCOIN to ADONAI
- replace Bitcoin/BTC references with Adonai/ADO

## Testing
- `cmake --build build --target adonai_consensus`
- `ctest --test-dir build -j2` *(fails: Unable to find executable /workspace/ADONAI/build/bin/test_adonai)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e5b2e344832db57b71f52c182577