### PR TITLE
refactor: replace bitcoin with adonai in interfaces

### DIFF
--- a/src/interfaces/README.md
+++ b/src/interfaces/README.md
@@ -6,7 +6,7 @@ The following interfaces are defined here:
 
 * [`ChainClient`](chain.h) — used by node to start & stop `Chain` clients. Added in [#14437](https://github.com/bitcoin/bitcoin/pull/14437).
 
-* [`Node`](node.h) — used by GUI to start & stop bitcoin node. Added in [#10244](https://github.com/bitcoin/bitcoin/pull/10244).
+* [`Node`](node.h) — used by GUI to start & stop adonai node. Added in [#10244](https://github.com/bitcoin/bitcoin/pull/10244).
 
 * [`Wallet`](wallet.h) — used by GUI to access wallets. Added in [#10244](https://github.com/bitcoin/bitcoin/pull/10244).
 
@@ -16,4 +16,4 @@ The following interfaces are defined here:
 
 * [`Ipc`](ipc.h) — used by multiprocess code to access `Init` interface across processes. Added in [#19160](https://github.com/bitcoin/bitcoin/pull/19160).
 
-The interfaces above define boundaries between major components of bitcoin code (node, wallet, and gui), making it possible for them to run in [different processes](../../doc/multiprocess.md), and be tested, developed, and understood independently. These interfaces are not currently designed to be stable or to be used externally.
+The interfaces above define boundaries between major components of adonai code (node, wallet, and gui), making it possible for them to run in [different processes](../../doc/multiprocess.md), and be tested, developed, and understood independently. These interfaces are not currently designed to be stable or to be used externally.

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_INTERFACES_CHAIN_H
-#define BITCOIN_INTERFACES_CHAIN_H
+#ifndef ADONAI_INTERFACES_CHAIN_H
+#define ADONAI_INTERFACES_CHAIN_H
 
 #include <blockfilter.h>
 #include <common/settings.h>
@@ -108,7 +108,7 @@ using SettingsUpdate = std::function<std::optional<interfaces::SettingsAction>(c
 //! estimate fees, and submit transactions.
 //!
 //! TODO: Current chain methods are too low level, exposing too much of the
-//! internal workings of the bitcoin node, and not being very convenient to use.
+//! internal workings of the adonai node, and not being very convenient to use.
 //! Chain methods should be cleaned up and simplified over time. Examples:
 //!
 //! * The initMessages() and showProgress() methods which the wallet uses to send
@@ -432,4 +432,4 @@ std::unique_ptr<Chain> MakeChain(node::NodeContext& node);
 
 } // namespace interfaces
 
-#endif // BITCOIN_INTERFACES_CHAIN_H
+#endif // ADONAI_INTERFACES_CHAIN_H

--- a/src/interfaces/echo.h
+++ b/src/interfaces/echo.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_INTERFACES_ECHO_H
-#define BITCOIN_INTERFACES_ECHO_H
+#ifndef ADONAI_INTERFACES_ECHO_H
+#define ADONAI_INTERFACES_ECHO_H
 
 #include <memory>
 #include <string>
@@ -24,4 +24,4 @@ public:
 std::unique_ptr<Echo> MakeEcho();
 } // namespace interfaces
 
-#endif // BITCOIN_INTERFACES_ECHO_H
+#endif // ADONAI_INTERFACES_ECHO_H

--- a/src/interfaces/handler.h
+++ b/src/interfaces/handler.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_INTERFACES_HANDLER_H
-#define BITCOIN_INTERFACES_HANDLER_H
+#ifndef ADONAI_INTERFACES_HANDLER_H
+#define ADONAI_INTERFACES_HANDLER_H
 
 #include <functional>
 #include <memory>
@@ -37,4 +37,4 @@ std::unique_ptr<Handler> MakeCleanupHandler(std::function<void()> cleanup);
 
 } // namespace interfaces
 
-#endif // BITCOIN_INTERFACES_HANDLER_H
+#endif // ADONAI_INTERFACES_HANDLER_H

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_INTERFACES_INIT_H
-#define BITCOIN_INTERFACES_INIT_H
+#ifndef ADONAI_INTERFACES_INIT_H
+#define ADONAI_INTERFACES_INIT_H
 
 #include <interfaces/chain.h>
 #include <interfaces/echo.h>
@@ -25,7 +25,7 @@ class Ipc;
 //! and get access to other interfaces (Node, Chain, Wallet, etc).
 //!
 //! There is a different Init interface implementation for each process
-//! (bitcoin-gui, bitcoin-node, bitcoin-wallet, bitcoind, bitcoin-qt) and each
+//! (adonai-gui, adonai-node, adonai-wallet, adonaid, adonai-qt) and each
 //! implementation can implement the make methods for interfaces it supports.
 //! The default make methods all return null.
 class Init
@@ -56,4 +56,4 @@ std::unique_ptr<Init> MakeWalletInit(int argc, char* argv[], int& exit_status);
 std::unique_ptr<Init> MakeGuiInit(int argc, char* argv[]);
 } // namespace interfaces
 
-#endif // BITCOIN_INTERFACES_INIT_H
+#endif // ADONAI_INTERFACES_INIT_H

--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_INTERFACES_IPC_H
-#define BITCOIN_INTERFACES_IPC_H
+#ifndef ADONAI_INTERFACES_IPC_H
+#define ADONAI_INTERFACES_IPC_H
 
 #include <functional>
 #include <memory>
@@ -92,4 +92,4 @@ protected:
 std::unique_ptr<Ipc> MakeIpc(const char* exe_name, const char* process_argv0, Init& init);
 } // namespace interfaces
 
-#endif // BITCOIN_INTERFACES_IPC_H
+#endif // ADONAI_INTERFACES_IPC_H

--- a/src/interfaces/mining.h
+++ b/src/interfaces/mining.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_INTERFACES_MINING_H
-#define BITCOIN_INTERFACES_MINING_H
+#ifndef ADONAI_INTERFACES_MINING_H
+#define ADONAI_INTERFACES_MINING_H
 
 #include <consensus/amount.h>
 #include <interfaces/types.h>
@@ -140,4 +140,4 @@ std::unique_ptr<Mining> MakeMining(node::NodeContext& node);
 
 } // namespace interfaces
 
-#endif // BITCOIN_INTERFACES_MINING_H
+#endif // ADONAI_INTERFACES_MINING_H

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_INTERFACES_NODE_H
-#define BITCOIN_INTERFACES_NODE_H
+#ifndef ADONAI_INTERFACES_NODE_H
+#define ADONAI_INTERFACES_NODE_H
 
 #include <common/settings.h>
 #include <consensus/amount.h>
@@ -66,7 +66,7 @@ public:
     virtual std::string getName() = 0;
 };
 
-//! Top-level interface for a bitcoin node (bitcoind process).
+//! Top-level interface for an adonai node (adonaid process).
 class Node
 {
 public:
@@ -106,7 +106,7 @@ public:
     //! would be ignored because it is also specified in the command line.
     virtual bool isSettingIgnored(const std::string& name) = 0;
 
-    //! Return setting value from <datadir>/settings.json or bitcoin.conf.
+    //! Return setting value from <datadir>/settings.json or adonai.conf.
     virtual common::SettingsValue getPersistentSetting(const std::string& name) = 0;
 
     //! Update a setting in <datadir>/settings.json.
@@ -282,4 +282,4 @@ struct BlockTip {
 
 } // namespace interfaces
 
-#endif // BITCOIN_INTERFACES_NODE_H
+#endif // ADONAI_INTERFACES_NODE_H

--- a/src/interfaces/types.h
+++ b/src/interfaces/types.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_INTERFACES_TYPES_H
-#define BITCOIN_INTERFACES_TYPES_H
+#ifndef ADONAI_INTERFACES_TYPES_H
+#define ADONAI_INTERFACES_TYPES_H
 
 #include <uint256.h>
 
@@ -18,4 +18,4 @@ struct BlockRef {
 
 } // namespace interfaces
 
-#endif // BITCOIN_INTERFACES_TYPES_H
+#endif // ADONAI_INTERFACES_TYPES_H

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_INTERFACES_WALLET_H
-#define BITCOIN_INTERFACES_WALLET_H
+#ifndef ADONAI_INTERFACES_WALLET_H
+#define ADONAI_INTERFACES_WALLET_H
 
 #include <addresstype.h>
 #include <common/signmessage.h>
@@ -442,4 +442,4 @@ std::unique_ptr<WalletLoader> MakeWalletLoader(Chain& chain, ArgsManager& args);
 
 } // namespace interfaces
 
-#endif // BITCOIN_INTERFACES_WALLET_H
+#endif // ADONAI_INTERFACES_WALLET_H


### PR DESCRIPTION
## Summary
- replace bitcoin with adonai across interface documentation and comments
- update interface header guards to use ADONAI prefix

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Boost")*

------
https://chatgpt.com/codex/tasks/task_e_68b2e59c7cec832d987d8e84d53acf2f