### PR TITLE
refactor: rename bitcoin to adonai in common

### DIFF
--- a/src/common/args.h
+++ b/src/common/args.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_COMMON_ARGS_H
-#define BITCOIN_COMMON_ARGS_H
+#ifndef ADONAI_COMMON_ARGS_H
+#define ADONAI_COMMON_ARGS_H
 
 #include <common/settings.h>
 #include <compat/compat.h>
@@ -496,4 +496,4 @@ private:
 #endif
 } // namespace common
 
-#endif // BITCOIN_COMMON_ARGS_H
+#endif // ADONAI_COMMON_ARGS_H

--- a/src/common/bloom.h
+++ b/src/common/bloom.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_COMMON_BLOOM_H
-#define BITCOIN_COMMON_BLOOM_H
+#ifndef ADONAI_COMMON_BLOOM_H
+#define ADONAI_COMMON_BLOOM_H
 
 #include <serialize.h>
 #include <span.h>
@@ -125,4 +125,4 @@ private:
     int nHashFuncs;
 };
 
-#endif // BITCOIN_COMMON_BLOOM_H
+#endif // ADONAI_COMMON_BLOOM_H

--- a/src/common/init.h
+++ b/src/common/init.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_COMMON_INIT_H
-#define BITCOIN_COMMON_INIT_H
+#ifndef ADONAI_COMMON_INIT_H
+#define ADONAI_COMMON_INIT_H
 
 #include <util/translation.h>
 
@@ -37,4 +37,4 @@ using SettingsAbortFn = std::function<bool(const bilingual_str& message, const s
 std::optional<ConfigError> InitConfig(ArgsManager& args, SettingsAbortFn settings_abort_fn = nullptr);
 } // namespace common
 
-#endif // BITCOIN_COMMON_INIT_H
+#endif // ADONAI_COMMON_INIT_H

--- a/src/common/messages.h
+++ b/src/common/messages.h
@@ -9,8 +9,8 @@
 //! messages, and are called in different parts of the codebase across
 //! node/wallet/gui boundaries.
 
-#ifndef BITCOIN_COMMON_MESSAGES_H
-#define BITCOIN_COMMON_MESSAGES_H
+#ifndef ADONAI_COMMON_MESSAGES_H
+#define ADONAI_COMMON_MESSAGES_H
 
 #include <string>
 
@@ -38,4 +38,4 @@ bilingual_str AmountHighWarn(const std::string& optname);
 bilingual_str AmountErrMsg(const std::string& optname, const std::string& strValue);
 } // namespace common
 
-#endif // BITCOIN_COMMON_MESSAGES_H
+#endif // ADONAI_COMMON_MESSAGES_H

--- a/src/common/netif.cpp
+++ b/src/common/netif.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include <bitcoin-build-config.h> // IWYU pragma: keep
+#include <adonai-build-config.h> // IWYU pragma: keep
 
 #include <common/netif.h>
 

--- a/src/common/netif.h
+++ b/src/common/netif.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_COMMON_NETIF_H
-#define BITCOIN_COMMON_NETIF_H
+#ifndef ADONAI_COMMON_NETIF_H
+#define ADONAI_COMMON_NETIF_H
 
 #include <netaddress.h>
 
@@ -17,4 +17,4 @@ std::optional<CNetAddr> QueryDefaultGateway(Network network);
 //! Return all local non-loopback IPv4 and IPv6 network addresses.
 std::vector<CNetAddr> GetLocalAddresses();
 
-#endif // BITCOIN_COMMON_NETIF_H
+#endif // ADONAI_COMMON_NETIF_H

--- a/src/common/pcp.h
+++ b/src/common/pcp.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_COMMON_PCP_H
-#define BITCOIN_COMMON_PCP_H
+#ifndef ADONAI_COMMON_PCP_H
+#define ADONAI_COMMON_PCP_H
 
 #include <netaddress.h>
 
@@ -66,4 +66,4 @@ std::variant<MappingResult, MappingError> NATPMPRequestPortMap(const CNetAddr &g
 //! Returns the external_ip:external_port of the mapping if successful, otherwise a MappingError.
 std::variant<MappingResult, MappingError> PCPRequestPortMap(const PCPMappingNonce &nonce, const CNetAddr &gateway, const CNetAddr &bind, uint16_t port, uint32_t lifetime, int num_tries = 3, std::chrono::milliseconds timeout_per_try = std::chrono::milliseconds(1000));
 
-#endif // BITCOIN_COMMON_PCP_H
+#endif // ADONAI_COMMON_PCP_H

--- a/src/common/run_command.cpp
+++ b/src/common/run_command.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bitcoin-build-config.h> // IWYU pragma: keep
+#include <adonai-build-config.h> // IWYU pragma: keep
 
 #include <common/run_command.h>
 

--- a/src/common/run_command.h
+++ b/src/common/run_command.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_COMMON_RUN_COMMAND_H
-#define BITCOIN_COMMON_RUN_COMMAND_H
+#ifndef ADONAI_COMMON_RUN_COMMAND_H
+#define ADONAI_COMMON_RUN_COMMAND_H
 
 #include <string>
 
@@ -19,4 +19,4 @@ class UniValue;
  */
 UniValue RunCommandParseJSON(const std::string& str_command, const std::string& str_std_in="");
 
-#endif // BITCOIN_COMMON_RUN_COMMAND_H
+#endif // ADONAI_COMMON_RUN_COMMAND_H

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -5,7 +5,7 @@
 
 #include <common/settings.h>
 
-#include <bitcoin-build-config.h> // IWYU pragma: keep
+#include <adonai-build-config.h> // IWYU pragma: keep
 
 #include <tinyformat.h>
 #include <univalue.h>

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_COMMON_SETTINGS_H
-#define BITCOIN_COMMON_SETTINGS_H
+#ifndef ADONAI_COMMON_SETTINGS_H
+#define ADONAI_COMMON_SETTINGS_H
 
 #include <util/fs.h>
 
@@ -113,4 +113,4 @@ auto FindKey(Map&& map, Key&& key) -> decltype(&map.at(key))
 
 } // namespace common
 
-#endif // BITCOIN_COMMON_SETTINGS_H
+#endif // ADONAI_COMMON_SETTINGS_H

--- a/src/common/signmessage.cpp
+++ b/src/common/signmessage.cpp
@@ -22,7 +22,7 @@
  * Text used to signify that a signed message follows and to prevent
  * inadvertently signing a transaction.
  */
-const std::string MESSAGE_MAGIC = "Bitcoin Signed Message:\n";
+const std::string MESSAGE_MAGIC = "Adonai Signed Message:\n";
 
 MessageVerificationResult MessageVerify(
     const std::string& address,

--- a/src/common/signmessage.h
+++ b/src/common/signmessage.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_COMMON_SIGNMESSAGE_H
-#define BITCOIN_COMMON_SIGNMESSAGE_H
+#ifndef ADONAI_COMMON_SIGNMESSAGE_H
+#define ADONAI_COMMON_SIGNMESSAGE_H
 
 #include <uint256.h>
 
@@ -48,7 +48,7 @@ enum class SigningResult {
 };
 
 /** Verify a signed message.
- * @param[in] address Signer's bitcoin address, it must refer to a public key.
+ * @param[in] address Signer's adonai address, it must refer to a public key.
  * @param[in] signature The signature in base64 format.
  * @param[in] message The message that was signed.
  * @return result code */
@@ -75,4 +75,4 @@ uint256 MessageHash(const std::string& message);
 
 std::string SigningResultString(const SigningResult res);
 
-#endif // BITCOIN_COMMON_SIGNMESSAGE_H
+#endif // ADONAI_COMMON_SIGNMESSAGE_H

--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -4,7 +4,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bitcoin-build-config.h> // IWYU pragma: keep
+#include <adonai-build-config.h> // IWYU pragma: keep
 
 #include <common/system.h>
 

--- a/src/common/system.h
+++ b/src/common/system.h
@@ -4,10 +4,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_COMMON_SYSTEM_H
-#define BITCOIN_COMMON_SYSTEM_H
+#ifndef ADONAI_COMMON_SYSTEM_H
+#define ADONAI_COMMON_SYSTEM_H
 
-#include <bitcoin-build-config.h> // IWYU pragma: keep
+#include <adonai-build-config.h> // IWYU pragma: keep
 
 #include <cstdint>
 #include <string>
@@ -30,4 +30,4 @@ void runCommand(const std::string& strCommand);
  */
 int GetNumCores();
 
-#endif // BITCOIN_COMMON_SYSTEM_H
+#endif // ADONAI_COMMON_SYSTEM_H

--- a/src/common/url.h
+++ b/src/common/url.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_COMMON_URL_H
-#define BITCOIN_COMMON_URL_H
+#ifndef ADONAI_COMMON_URL_H
+#define ADONAI_COMMON_URL_H
 
 #include <string>
 #include <string_view>
@@ -15,4 +15,4 @@
  */
 std::string UrlDecode(std::string_view url_encoded);
 
-#endif // BITCOIN_COMMON_URL_H
+#endif // ADONAI_COMMON_URL_H


### PR DESCRIPTION
## Summary
- update common headers from BITCOIN to ADONAI and switch build config includes
- rename signed message magic and comments to "Adonai"

## Testing
- `cmake -S . -B build`
- `cmake --build build --target adonai_common` *(fails: interrupted during build)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e5694c54832dab3636a7a6538e1c