### PR TITLE
refactor: rename bench to adonai

### DIFF
--- a/cmake/module/Maintenance.cmake
+++ b/cmake/module/Maintenance.cmake
@@ -23,7 +23,7 @@ function(add_maintenance_targets)
     return()
   endif()
 
-  foreach(target IN ITEMS bitcoin bitcoind bitcoin-qt bitcoin-cli bitcoin-tx bitcoin-util bitcoin-wallet test_bitcoin bench_bitcoin)
+  foreach(target IN ITEMS bitcoin bitcoind bitcoin-qt bitcoin-cli bitcoin-tx bitcoin-util bitcoin-wallet test_bitcoin bench_adonai)
     if(TARGET ${target})
       list(APPEND executables $<TARGET_FILE:${target}>)
     endif()

--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -1,24 +1,24 @@
 Benchmarking
 ============
 
-Bitcoin Core has an internal benchmarking framework, with benchmarks
+Adonai Core has an internal benchmarking framework, with benchmarks
 for cryptographic algorithms (e.g. SHA1, SHA256, SHA512, RIPEMD160, Poly1305, ChaCha20), rolling bloom filter, coins selection,
 thread queue, wallet balance.
 
 Running
 ---------------------
 
-For benchmarking, you only need to compile `bench_bitcoin`.  The bench runner
+For benchmarking, you only need to compile `bench_adonai`.  The bench runner
 warns if you configure with `-DCMAKE_BUILD_TYPE=Debug`, but consider if building without
 it will impact the benchmark(s) you are interested in by unlatching log printers
 and lock analysis.
 
     cmake -B build -DBUILD_BENCH=ON
-    cmake --build build -t bench_bitcoin
+    cmake --build build -t bench_adonai
 
-After compiling bitcoin-core, the benchmarks can be run with:
+After compiling adonai-core, the benchmarks can be run with:
 
-    build/bin/bench_bitcoin
+    build/bin/bench_adonai
 
 The output will look similar to:
 ```
@@ -40,7 +40,7 @@ The output will look similar to:
 Help
 ---------------------
 
-    build/bin/bench_bitcoin -h
+    build/bin/bench_adonai -h
 
 To print the various options, like listing the benchmarks without running them
 or using a regex filter to only run certain benchmarks.
@@ -74,4 +74,4 @@ specifically aimed at exploring the possible input space.
 Going Further
 --------------------
 
-To monitor Bitcoin Core performance more in depth (like reindex or IBD): https://github.com/bitcoin-dev-tools/benchcoin
+To monitor Adonai Core performance more in depth (like reindex or IBD): https://github.com/bitcoin-dev-tools/benchcoin

--- a/doc/productivity.md
+++ b/doc/productivity.md
@@ -68,9 +68,9 @@ When rebuilding during development, note that running `cmake --build build`, wit
 Obviously, it is important to build and run the tests at appropriate times -- but when you just want a quick compile to check your work, consider picking one or a set of build targets relevant to what you're working on, e.g.:
 
 ```sh
-cmake --build build --target bitcoind bitcoin-cli
-cmake --build build --target bitcoin-qt
-cmake --build build --target bench_bitcoin
+cmake --build build --target adonaid adonai-cli
+cmake --build build --target adonai-qt
+cmake --build build --target bench_adonai
 ```
 
 (You can and should combine this with `-j`, as above, for a parallel build.)

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -3,8 +3,8 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_executable(bench_bitcoin
-  bench_bitcoin.cpp
+add_executable(bench_adonai
+  bench_adonai.cpp
   bench.cpp
   nanobench.cpp
 # Benchmarks:
@@ -56,11 +56,11 @@ add_executable(bench_bitcoin
 )
 
 include(TargetDataSources)
-target_raw_data_sources(bench_bitcoin NAMESPACE benchmark::data
+target_raw_data_sources(bench_adonai NAMESPACE benchmark::data
   data/block413567.raw
 )
 
-target_link_libraries(bench_bitcoin
+target_link_libraries(bench_adonai
   core_interface
   test_util
   adonai_node
@@ -68,7 +68,7 @@ target_link_libraries(bench_bitcoin
 )
 
 if(ENABLE_WALLET)
-  target_sources(bench_bitcoin
+  target_sources(bench_adonai
     PRIVATE
       coin_selection.cpp
       wallet_balance.cpp
@@ -78,11 +78,11 @@ if(ENABLE_WALLET)
       wallet_ismine.cpp
       wallet_migration.cpp
   )
-  target_link_libraries(bench_bitcoin adonai_wallet)
+  target_link_libraries(bench_adonai adonai_wallet)
 endif()
 
 add_test(NAME bench_sanity_check
-  COMMAND bench_bitcoin -sanity-check
+  COMMAND bench_adonai -sanity-check
 )
 
-install_binary_component(bench_bitcoin)
+install_binary_component(bench_adonai)

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_BENCH_BENCH_H
-#define BITCOIN_BENCH_BENCH_H
+#ifndef ADONAI_BENCH_BENCH_H
+#define ADONAI_BENCH_BENCH_H
 
 #include <bench/nanobench.h> // IWYU pragma: export
 #include <util/fs.h>
@@ -82,4 +82,4 @@ public:
 #define BENCHMARK(n, priority_level) \
     benchmark::BenchRunner PASTE2(bench_, PASTE2(__LINE__, n))(STRINGIZE(n), n, priority_level);
 
-#endif // BITCOIN_BENCH_BENCH_H
+#endif // ADONAI_BENCH_BENCH_H

--- a/src/bench/bench_adonai.cpp
+++ b/src/bench/bench_adonai.cpp
@@ -87,12 +87,12 @@ int main(int argc, char** argv)
     }
 
     if (HelpRequested(argsman)) {
-        std::cout << "Usage:  bench_bitcoin [options]\n"
+        std::cout << "Usage:  bench_adonai [options]\n"
                      "\n"
                   << argsman.GetHelpMessage()
                   << "Description:\n"
                      "\n"
-                     "  bench_bitcoin executes microbenchmarks. The quality of the benchmark results\n"
+                     "  bench_adonai executes microbenchmarks. The quality of the benchmark results\n"
                      "  highly depend on the stability of the machine. It can sometimes be difficult\n"
                      "  to get stable, repeatable results, so here are a few tips:\n"
                      "\n"
@@ -106,7 +106,7 @@ int main(int argc, char** argv)
                      "  * If results are still not reliable, increase runtime with e.g.\n"
                      "    -min-time=5000 to let a benchmark run for at least 5 seconds.\n"
                      "\n"
-                     "  * bench_bitcoin uses nanobench [3] for which there is extensive\n"
+                     "  * bench_adonai uses nanobench [3] for which there is extensive\n"
                      "    documentation available online.\n"
                      "\n"
                      "Environment Variables:\n"
@@ -114,12 +114,12 @@ int main(int argc, char** argv)
                      "  To attach a profiler you can run a benchmark in endless mode. This can be\n"
                      "  done with the environment variable NANOBENCH_ENDLESS. E.g. like so:\n"
                      "\n"
-                     "    NANOBENCH_ENDLESS=MuHash ./bench_bitcoin -filter=MuHash\n"
+                     "    NANOBENCH_ENDLESS=MuHash ./bench_adonai -filter=MuHash\n"
                      "\n"
                      "  In rare cases it can be useful to suppress stability warnings. This can be\n"
                      "  done with the environment variable NANOBENCH_SUPPRESS_WARNINGS, e.g:\n"
                      "\n"
-                     "    NANOBENCH_SUPPRESS_WARNINGS=1 ./bench_bitcoin\n"
+                     "    NANOBENCH_SUPPRESS_WARNINGS=1 ./bench_adonai\n"
                      "\n"
                      "Notes:\n"
                      "\n"

--- a/src/bench/connectblock.cpp
+++ b/src/bench/connectblock.cpp
@@ -67,7 +67,7 @@ CBlock CreateTestBlock(
  * Creates key pairs and corresponding outputs for the benchmark transactions.
  * - For Schnorr signatures: Creates simple key path spendable outputs
  * - For Ecdsa signatures: Creates P2WPKH (native SegWit v0) outputs
- * - All outputs have value of 1 BTC
+ * - All outputs have value of 1 ADO
  */
 std::pair<std::vector<CKey>, std::vector<CTxOut>> CreateKeysAndOutputs(const CKey& coinbaseKey, size_t num_schnorr, size_t num_ecdsa)
 {

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -144,7 +144,7 @@ static void WalletCreateTx(benchmark::Bench& bench, const OutputType output_type
 
     CAmount target = 0;
     if (preset_inputs) {
-        // Select inputs, each has 48 BTC
+        // Select inputs, each has 48 ADO
         wallet::CoinFilterParams filter_coins;
         filter_coins.max_count = preset_inputs->num_of_internal_inputs;
         const auto& res = WITH_LOCK(wallet.cs_wallet,


### PR DESCRIPTION
## Summary
- rename `bench_bitcoin` to `bench_adonai`
- update documentation and build scripts to use Adonai naming
- adjust comments and headers to replace BTC with ADO

## Testing
- `cmake -B build -GNinja -DBUILD_BENCH=ON`
- `cmake --build build --target bench_adonai` *(fails: build interrupted by user)*

------
https://chatgpt.com/codex/tasks/task_e_68b30ea07a20832d9ca86664aa80a9b1