### PR TITLE
refactor: rename bitcoin to adonai in IPC module

### DIFF
--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -1,22 +1,23 @@
 # Copyright (c) 2023-present The Bitcoin Core developers
+# Modifications (c) 2025 The Adonai Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_library(bitcoin_ipc STATIC EXCLUDE_FROM_ALL
+add_library(adonai_ipc STATIC EXCLUDE_FROM_ALL
   capnp/mining.cpp
   capnp/protocol.cpp
   interfaces.cpp
   process.cpp
 )
 
-target_capnp_sources(bitcoin_ipc ${PROJECT_SOURCE_DIR}
+target_capnp_sources(adonai_ipc ${PROJECT_SOURCE_DIR}
   capnp/common.capnp
   capnp/echo.capnp
   capnp/init.capnp
   capnp/mining.capnp
 )
 
-target_link_libraries(bitcoin_ipc
+target_link_libraries(adonai_ipc
   PRIVATE
     core_interface
     univalue

--- a/src/ipc/capnp/common-types.h
+++ b/src/ipc/capnp/common-types.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_IPC_CAPNP_COMMON_TYPES_H
-#define BITCOIN_IPC_CAPNP_COMMON_TYPES_H
+#ifndef ADONAI_IPC_CAPNP_COMMON_TYPES_H
+#define ADONAI_IPC_CAPNP_COMMON_TYPES_H
 
 #include <clientversion.h>
 #include <interfaces/types.h>
@@ -34,7 +34,7 @@
 namespace ipc {
 namespace capnp {
 //! Construct a ParamStream wrapping a data stream with serialization parameters
-//! needed to pass transaction objects between bitcoin processes.
+//! needed to pass transaction objects between adonai processes.
 //! In the future, more params may be added here to serialize other objects that
 //! require serialization parameters. Params should just be chosen to serialize
 //! objects completely and ensure that serializing and deserializing objects
@@ -54,7 +54,7 @@ concept Deserializable = std::is_constructible_v<T, ::deserialize_type, ::DataSt
 } // namespace capnp
 } // namespace ipc
 
-//! Functions to serialize / deserialize common bitcoin types.
+//! Functions to serialize / deserialize common adonai types.
 namespace mp {
 //! Overload multiprocess library's CustomBuildField hook to allow any
 //! serializable object to be stored in a capnproto Data field or passed to a
@@ -130,4 +130,4 @@ decltype(auto) CustomReadField(TypeList<UniValue>, Priority<1>, InvokeContext& i
 
 } // namespace mp
 
-#endif // BITCOIN_IPC_CAPNP_COMMON_TYPES_H
+#endif // ADONAI_IPC_CAPNP_COMMON_TYPES_H

--- a/src/ipc/capnp/common.capnp
+++ b/src/ipc/capnp/common.capnp
@@ -1,4 +1,5 @@
 # Copyright (c) 2024 The Bitcoin Core developers
+# Modifications (c) 2025 The Adonai Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/ipc/capnp/context.h
+++ b/src/ipc/capnp/context.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_IPC_CAPNP_CONTEXT_H
-#define BITCOIN_IPC_CAPNP_CONTEXT_H
+#ifndef ADONAI_IPC_CAPNP_CONTEXT_H
+#define ADONAI_IPC_CAPNP_CONTEXT_H
 
 #include <ipc/context.h>
 
@@ -21,4 +21,4 @@ struct Context : ipc::Context
 } // namespace capnp
 } // namespace ipc
 
-#endif // BITCOIN_IPC_CAPNP_CONTEXT_H
+#endif // ADONAI_IPC_CAPNP_CONTEXT_H

--- a/src/ipc/capnp/echo-types.h
+++ b/src/ipc/capnp/echo-types.h
@@ -3,11 +3,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_IPC_CAPNP_ECHO_TYPES_H
-#define BITCOIN_IPC_CAPNP_ECHO_TYPES_H
+#ifndef ADONAI_IPC_CAPNP_ECHO_TYPES_H
+#define ADONAI_IPC_CAPNP_ECHO_TYPES_H
 
 #include <mp/type-context.h>
 #include <mp/type-decay.h>
 #include <mp/type-string.h>
 
-#endif // BITCOIN_IPC_CAPNP_ECHO_TYPES_H
+#endif // ADONAI_IPC_CAPNP_ECHO_TYPES_H

--- a/src/ipc/capnp/echo.capnp
+++ b/src/ipc/capnp/echo.capnp
@@ -1,4 +1,5 @@
 # Copyright (c) 2021 The Bitcoin Core developers
+# Modifications (c) 2025 The Adonai Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -3,10 +3,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_IPC_CAPNP_INIT_TYPES_H
-#define BITCOIN_IPC_CAPNP_INIT_TYPES_H
+#ifndef ADONAI_IPC_CAPNP_INIT_TYPES_H
+#define ADONAI_IPC_CAPNP_INIT_TYPES_H
 
 #include <ipc/capnp/echo.capnp.proxy-types.h>
 #include <ipc/capnp/mining.capnp.proxy-types.h>
 
-#endif // BITCOIN_IPC_CAPNP_INIT_TYPES_H
+#endif // ADONAI_IPC_CAPNP_INIT_TYPES_H

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -1,4 +1,5 @@
 # Copyright (c) 2021 The Bitcoin Core developers
+# Modifications (c) 2025 The Adonai Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/ipc/capnp/mining-types.h
+++ b/src/ipc/capnp/mining-types.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_IPC_CAPNP_MINING_TYPES_H
-#define BITCOIN_IPC_CAPNP_MINING_TYPES_H
+#ifndef ADONAI_IPC_CAPNP_MINING_TYPES_H
+#define ADONAI_IPC_CAPNP_MINING_TYPES_H
 
 #include <interfaces/mining.h>
 #include <ipc/capnp/common.capnp.proxy-types.h>
@@ -18,4 +18,4 @@ namespace mp {
 // Custom serializations
 } // namespace mp
 
-#endif // BITCOIN_IPC_CAPNP_MINING_TYPES_H
+#endif // ADONAI_IPC_CAPNP_MINING_TYPES_H

--- a/src/ipc/capnp/mining.capnp
+++ b/src/ipc/capnp/mining.capnp
@@ -1,4 +1,5 @@
 # Copyright (c) 2024 The Bitcoin Core developers
+# Modifications (c) 2025 The Adonai Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/ipc/capnp/protocol.h
+++ b/src/ipc/capnp/protocol.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_IPC_CAPNP_PROTOCOL_H
-#define BITCOIN_IPC_CAPNP_PROTOCOL_H
+#ifndef ADONAI_IPC_CAPNP_PROTOCOL_H
+#define ADONAI_IPC_CAPNP_PROTOCOL_H
 
 #include <memory>
 
@@ -15,4 +15,4 @@ std::unique_ptr<Protocol> MakeCapnpProtocol();
 } // namespace capnp
 } // namespace ipc
 
-#endif // BITCOIN_IPC_CAPNP_PROTOCOL_H
+#endif // ADONAI_IPC_CAPNP_PROTOCOL_H

--- a/src/ipc/context.h
+++ b/src/ipc/context.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_IPC_CONTEXT_H
-#define BITCOIN_IPC_CONTEXT_H
+#ifndef ADONAI_IPC_CONTEXT_H
+#define ADONAI_IPC_CONTEXT_H
 
 namespace ipc {
 //! Context struct used to give IPC protocol implementations or implementation
@@ -17,4 +17,4 @@ struct Context
 };
 } // namespace ipc
 
-#endif // BITCOIN_IPC_CONTEXT_H
+#endif // ADONAI_IPC_CONTEXT_H

--- a/src/ipc/exception.h
+++ b/src/ipc/exception.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_IPC_EXCEPTION_H
-#define BITCOIN_IPC_EXCEPTION_H
+#ifndef ADONAI_IPC_EXCEPTION_H
+#define ADONAI_IPC_EXCEPTION_H
 
 #include <stdexcept>
 
@@ -18,4 +18,4 @@ public:
 };
 } // namespace ipc
 
-#endif // BITCOIN_IPC_EXCEPTION_H
+#endif // ADONAI_IPC_EXCEPTION_H

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -78,7 +78,7 @@ static bool ParseAddress(std::string& address,
     if (address == "unix" || address.starts_with("unix:")) {
         fs::path path;
         if (address.size() <= 5) {
-            path = data_dir / fs::PathFromString(strprintf("%s.sock", RemovePrefixView(dest_exe_name, "bitcoin-")));
+            path = data_dir / fs::PathFromString(strprintf("%s.sock", RemovePrefixView(dest_exe_name, "adonai-")));
         } else {
             path = data_dir / fs::PathFromString(address.substr(5));
         }

--- a/src/ipc/process.h
+++ b/src/ipc/process.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_IPC_PROCESS_H
-#define BITCOIN_IPC_PROCESS_H
+#ifndef ADONAI_IPC_PROCESS_H
+#define ADONAI_IPC_PROCESS_H
 
 #include <util/fs.h>
 
@@ -14,7 +14,7 @@
 namespace ipc {
 class Protocol;
 
-//! IPC process interface for spawning bitcoin processes and serving requests
+//! IPC process interface for spawning adonai processes and serving requests
 //! in processes that have been spawned.
 //!
 //! There will be different implementations of this interface depending on the
@@ -52,4 +52,4 @@ public:
 std::unique_ptr<Process> MakeProcess();
 } // namespace ipc
 
-#endif // BITCOIN_IPC_PROCESS_H
+#endif // ADONAI_IPC_PROCESS_H

--- a/src/ipc/protocol.h
+++ b/src/ipc/protocol.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_IPC_PROTOCOL_H
-#define BITCOIN_IPC_PROTOCOL_H
+#ifndef ADONAI_IPC_PROTOCOL_H
+#define ADONAI_IPC_PROTOCOL_H
 
 #include <interfaces/init.h>
 
@@ -68,4 +68,4 @@ public:
 };
 } // namespace ipc
 
-#endif // BITCOIN_IPC_PROTOCOL_H
+#endif // ADONAI_IPC_PROTOCOL_H


### PR DESCRIPTION
## Summary
- replace bitcoin names with adonai equivalents in IPC code
- update license headers and include guards
- rename build target to `adonai_ipc` and adjust socket prefix

## Testing
- `cmake -S . -B build`
- `cmake --build build --target adonai_ipc` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_68b30f22c4e0832db79f73a58b428cbe