### PR TITLE
Remove obsolete tools directory

### DIFF
--- a/tools/add-headers.sh
+++ b/tools/add-headers.sh
@@ -1,7 +1,0 @@
-YEAR=2025
-while IFS= read -r -d '' f; do
-  if grep -q 'The Bitcoin Core developers' "$f" && ! grep -q 'The Adonai Core developers' "$f"; then
-    sed -i "/The Bitcoin Core developers/a // Modifications (c) ${YEAR} The Adonai Core developers" "$f"
-    echo "[CHANGE] $f"
-  fi
-done < <(find src -type f \( -name "*.h" -o -name "*.cpp" \) -print0)


### PR DESCRIPTION
## Summary
- remove unused tools directory and its add-headers.sh script

## Testing
- `python3 test/lint/lint-files.py` *(fails: missing shebang for multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68b3214bd7e8832db9b59d5e89054c31