### PR TITLE
Adjust subsidy and supply parameters

### DIFF
--- a/src/consensus/amount.h
+++ b/src/consensus/amount.h
@@ -18,13 +18,13 @@ static constexpr CAmount COIN = 100000000;
 /** No amount larger than this (in satoshi) is valid.
  *
  * Note that this constant is *not* the total money supply, which in Adonai
- * currently happens to be less than 280,320,000 ADO for various reasons, but
+ * currently happens to be less than 100,000,000 ADO for various reasons, but
  * rather a sanity check. As this sanity check is used by consensus-critical
  * validation code, the exact value of the MAX_MONEY constant is consensus
  * critical; in unusual circumstances like a(nother) overflow bug that allowed
  * for the creation of coins out of thin air modification could lead to a fork.
  * */
-static constexpr CAmount MAX_MONEY = 280320000 * COIN;
+static constexpr CAmount MAX_MONEY = 100000000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 #endif // ADONAI_CONSENSUS_AMOUNT_H

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -138,7 +138,7 @@ public:
         m_chain_type = ChainType::MAIN;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 2803200;
+        consensus.nSubsidyHalvingInterval = 1000000;
         consensus.script_flag_exceptions.clear();
 
         consensus.BIP34Height = 0;
@@ -283,7 +283,7 @@ public:
         m_chain_type = ChainType::TESTNET;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 2803200;
+        consensus.nSubsidyHalvingInterval = 1000000;
         consensus.script_flag_exceptions.emplace( // BIP16 exception
             uint256{"00000000dd30457c001f4095d208cc1296b0eed002427aa599874af7a432b105"}, SCRIPT_VERIFY_NONE);
         consensus.BIP34Height = 21111;
@@ -299,6 +299,7 @@ public:
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
+        consensus.nSubsidyInitial          = 50 * COIN;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
@@ -375,7 +376,7 @@ public:
         m_chain_type = ChainType::TESTNET4;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
-        consensus.nSubsidyHalvingInterval = 2803200;
+        consensus.nSubsidyHalvingInterval = 1000000;
         consensus.BIP34Height = 1;
         consensus.BIP34Hash = uint256{};
         consensus.BIP65Height = 1;
@@ -389,6 +390,7 @@ public:
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
+        consensus.nSubsidyInitial          = 50 * COIN;
 
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
@@ -494,7 +496,7 @@ public:
         consensus.signet_blocks = true;
         consensus.signet_challenge.assign(challenge_bin.begin(), challenge_bin.end());
 
-        consensus.nSubsidyHalvingInterval = 2803200;
+        consensus.nSubsidyHalvingInterval = 1000000;
         consensus.BIP34Height = 1;
         consensus.BIP34Hash = uint256{};
         consensus.BIP65Height = 1;
@@ -509,6 +511,7 @@ public:
         consensus.fPowNoRetargeting = false;
         consensus.enforce_BIP94 = false;
         consensus.MinBIP9WarningHeight = 0;
+        consensus.nSubsidyInitial          = 50 * COIN;
 
         
         consensus.powLimit = uint256{"7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
@@ -617,6 +620,7 @@ public:
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = opts.enforce_bip94;
         consensus.fPowNoRetargeting = true;
+        consensus.nSubsidyInitial          = 50 * COIN;
 
         consensus.nPowTargetTimespan = 45; // irrelevante con no-retarget, pero coherente
         consensus.nPowTargetSpacing = 45;  // Adonai: 45 s por bloque

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -21,8 +21,8 @@
 // amounts 1 .. 10000
 #define NUM_MULTIPLES_1ADO 10000
 
-// amounts 50 .. 280320000
-#define NUM_MULTIPLES_50ADO 5606400
+// amounts 50 .. 100000000
+#define NUM_MULTIPLES_50ADO 2000000
 
 BOOST_FIXTURE_TEST_SUITE(compress_tests, BasicTestingSetup)
 
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(compress_amounts)
     BOOST_CHECK(TestPair(         CENT,       0x7));
     BOOST_CHECK(TestPair(         COIN,       0x9));
     BOOST_CHECK(TestPair(      50*COIN,      0x32));
-    BOOST_CHECK(TestPair(280320000*COIN, 0x10b55800));
+    BOOST_CHECK(TestPair(100000000*COIN, 0x5f5e100));
 
     for (uint64_t i = 1; i <= NUM_MULTIPLES_UNIT; i++)
         BOOST_CHECK(TestEncode(i));

--- a/src/test/feefrac_tests.cpp
+++ b/src/test/feefrac_tests.cpp
@@ -127,24 +127,24 @@ BOOST_AUTO_TEST_CASE(feefrac_operators)
     FeeFrac busted{(static_cast<int64_t>(INT32_MAX)) + 1, INT32_MAX};
     BOOST_CHECK(!(busted < busted));
 
-    FeeFrac max_fee{28032000000000000, INT32_MAX};
+    FeeFrac max_fee{10000000000000000, INT32_MAX};
     BOOST_CHECK(!(max_fee < max_fee));
     BOOST_CHECK(!(max_fee > max_fee));
     BOOST_CHECK(max_fee <= max_fee);
     BOOST_CHECK(max_fee >= max_fee);
 
     BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(0), 0);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1), 13053417);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(2), 26106834);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(3), 39160251);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1256796054), 16405483243117799);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(INT32_MAX), 28032000000000000);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1), 4656612);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(2), 9313225);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(3), 13969838);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(1256796054), 5852412686614511);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeDown(INT32_MAX), 10000000000000000);
     BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(0), 0);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1), 13053418);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(2), 26106835);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(3), 39160252);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1256796054), 16405483243117800);
-    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(INT32_MAX), 28032000000000000);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1), 4656613);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(2), 9313226);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(3), 13969839);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(1256796054), 5852412686614512);
+    BOOST_CHECK_EQUAL(max_fee.EvaluateFeeUp(INT32_MAX), 10000000000000000);
 
     FeeFrac max_fee2{1, 1};
     BOOST_CHECK(max_fee >= max_fee2);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -408,8 +408,8 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
 
         // subsidy changing
         int nHeight = m_node.chainman->ActiveChain().Height();
-        // Create an actual 2,803,199-long block chain (without valid blocks).
-        while (m_node.chainman->ActiveChain().Tip()->nHeight < 2803199) {
+        // Create an actual 999,999-long block chain (without valid blocks).
+        while (m_node.chainman->ActiveChain().Tip()->nHeight < 999999) {
             CBlockIndex* prev = m_node.chainman->ActiveChain().Tip();
             CBlockIndex* next = new CBlockIndex();
             next->phashBlock = new uint256(m_rng.rand256());
@@ -420,8 +420,8 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
             m_node.chainman->ActiveChain().SetTip(*next);
         }
         BOOST_REQUIRE(mining->createNewBlock(options));
-        // Extend to a 2,803,200-long block chain.
-        while (m_node.chainman->ActiveChain().Tip()->nHeight < 2803200) {
+        // Extend to a 1,000,000-long block chain.
+        while (m_node.chainman->ActiveChain().Tip()->nHeight < 1000000) {
             CBlockIndex* prev = m_node.chainman->ActiveChain().Tip();
             CBlockIndex* next = new CBlockIndex();
             next->phashBlock = new uint256(m_rng.rand256());

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -212,8 +212,8 @@ struct DepGraphFormatter
                 // Read fee, encoded as an unsigned varint (odd=negative, even=non-negative).
                 uint64_t coded_fee;
                 s >> VARINT(coded_fee);
-                coded_fee &= 0xFFFFFFFFFFFFFF; // Enough for fee between -280M...280M ADO.
-                static_assert(0xFFFFFFFFFFFFFF > uint64_t{2} * 280320000 * 100000000);
+                coded_fee &= 0xFFFFFFFFFFFFFF; // Enough for fee between -100M...100M ADO.
+                static_assert(0xFFFFFFFFFFFFFF > uint64_t{2} * 100000000 * 100000000);
                 new_feerate = {UnsignedToSigned(coded_fee), size};
                 // Read dependency information.
                 auto topo_idx = reordering.size();

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -24,7 +24,7 @@ BOOST_FIXTURE_TEST_SUITE(validation_tests, TestingSetup)
 static void TestBlockSubsidyHalvings(const Consensus::Params& consensusParams)
 {
     int maxHalvings = 64;
-    CAmount nInitialSubsidy = 50 * COIN;
+    CAmount nInitialSubsidy = consensusParams.nSubsidyInitial;
 
     CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 0
     BOOST_CHECK_EQUAL(nPreviousSubsidy, nInitialSubsidy * 2);
@@ -42,6 +42,7 @@ static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
 {
     Consensus::Params consensusParams;
     consensusParams.nSubsidyHalvingInterval = nSubsidyHalvingInterval;
+    consensusParams.nSubsidyInitial = 50 * COIN;
     TestBlockSubsidyHalvings(consensusParams);
 }
 
@@ -59,11 +60,11 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
     CAmount nSum = 0;
     for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
         CAmount nSubsidy = GetBlockSubsidy(nHeight, chainParams->GetConsensus());
-        BOOST_CHECK(nSubsidy <= 50 * COIN);
+        BOOST_CHECK(nSubsidy <= chainParams->GetConsensus().nSubsidyInitial);
         nSum += nSubsidy * 1000;
         BOOST_CHECK(MoneyRange(nSum));
     }
-    BOOST_CHECK_EQUAL(nSum, CAmount{27154062500000000});
+    BOOST_CHECK_EQUAL(nSum, CAmount{9999389647000000});
 }
 
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1945,7 +1945,7 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     if (halvings >= 64)
         return 0;
 
-    CAmount nSubsidy = 50 * COIN;
+    CAmount nSubsidy = consensusParams.nSubsidyInitial;
     // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
     nSubsidy >>= halvings;
     return nSubsidy;

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -400,7 +400,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.log.info("Check a package that passes mempoolminfee but is evicted immediately after submission")
         mempoolmin_feerate = node.getmempoolinfo()["mempoolminfee"]
         current_mempool = node.getrawmempool(verbose=False)
-        worst_feerate_btcvb = Decimal("280320000")
+        worst_feerate_btcvb = Decimal("100000000")
         for txid in current_mempool:
             entry = node.getmempoolentry(txid)
             worst_feerate_btcvb = min(worst_feerate_btcvb, entry["fees"]["descendant"] / entry["descendantsize"])

--- a/test/functional/test_framework/compressor.py
+++ b/test/functional/test_framework/compressor.py
@@ -55,4 +55,4 @@ class TestFrameworkCompressor(unittest.TestCase):
         check_amount(1000000, 0x7)
         check_amount(COIN, 0x9)
         check_amount(50*COIN, 0x32)
-        check_amount(280320000*COIN, 0x10b55800)
+        check_amount(100000000*COIN, 0x5f5e100)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -39,7 +39,7 @@ MAX_BLOOM_FILTER_SIZE = 36000
 MAX_BLOOM_HASH_FUNCS = 50
 
 COIN = 100000000  # 1 btc in satoshis
-MAX_MONEY = 280320000 * COIN
+MAX_MONEY = 100000000 * COIN
 
 MAX_BIP125_RBF_SEQUENCE = 0xfffffffd  # Sequence number that is rbf-opt-in (BIP 125) and csv-opt-out (BIP 68)
 MAX_SEQUENCE_NONFINAL = 0xfffffffe  # Sequence number that is csv-opt-out (BIP 68)


### PR DESCRIPTION
## Summary
- lower MAX_MONEY to 100,000,000 ADO
- set halving interval to 1,000,000 blocks and define initial subsidy in consensus params
- have GetBlockSubsidy rely on consensus.nSubsidyInitial and update tests

## Testing
- `cmake -B build -G Ninja`
- `ninja -C build` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b33aceee9c832dbe3e5eafcf2d03aa