### PR TITLE
feat: switch to per-block LWMA difficulty

### DIFF
--- a/doc/pow.md
+++ b/doc/pow.md
@@ -1,0 +1,22 @@
+# Prueba de Trabajo (PoW)
+
+ADONAI utiliza BLAKE3 como función hash de Prueba de Trabajo. A partir de esta versión,
+la dificultad se ajusta en cada bloque usando el algoritmo **Linearly Weighted Moving Average (LWMA)**.
+
+## LWMA por bloque
+
+El objetivo es mantener un intervalo medio constante entre bloques. Para ello se toman los
+últimos *N* bloques (ventana) y se calcula un promedio ponderado de sus tiempos de resolución.
+Cada bloque más reciente recibe un peso mayor. El nuevo objetivo de dificultad se deriva de:
+
+```
+next_target = (avg_target * weighted_times) / k
+```
+
+donde `avg_target` es el promedio de los objetivos anteriores,
+`weighted_times` la suma de tiempos ponderados y `k = N*(N+1)*T/2`, siendo `T`
+el tiempo objetivo entre bloques.
+
+Este esquema reacciona de forma más rápida ante cambios bruscos de hashrate y evita
+oscilaciones asociadas a los reajustes por intervalos largos.
+

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -123,12 +123,12 @@ struct Params {
     bool enforce_BIP94;
     bool fPowNoRetargeting;
     int64_t nPowTargetSpacing;
-    int64_t nPowTargetTimespan;
+    int64_t nPowAveragingWindow;
     std::chrono::seconds PowTargetSpacing() const
     {
         return std::chrono::seconds{nPowTargetSpacing};
     }
-    int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
+    int64_t DifficultyAdjustmentInterval() const { return nPowAveragingWindow; }
     /** The best chain should have at least this much work */
     uint256 nMinimumChainWork;
     /** By default assume that the signatures in ancestors of this block are valid */

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -152,8 +152,8 @@ public:
         consensus.powLimit = uint256{"00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
 
         consensus.nPowTargetSpacingV1      = 120;     // arranque seguro
-        consensus.nPowTargetSpacing = 45; //time between blocks
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60;
+        consensus.nPowTargetSpacing = 45; // time between blocks
+        consensus.nPowAveragingWindow = 60; // LWMA window
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -294,8 +294,8 @@ public:
         consensus.SegwitHeight = 834624; // 00000000002b980fcd729daaa248fd9316a5200e9b367f4ff2c42453e84201ca
         consensus.MinBIP9WarningHeight = 836640; // segwit activation height + miner confirmation window
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowAveragingWindow = 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -385,8 +385,8 @@ public:
         consensus.SegwitHeight = 1;
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowAveragingWindow = 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
@@ -505,8 +505,8 @@ public:
         consensus.SegwitHeight = 1;
 
         // Timing objetivo ADONAI (mantén 60s si es tu target)
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // 2 semanas (estilo ADO; OK para tests)
         consensus.nPowTargetSpacing  = 60;                // 60 s (ADONAI)
+        consensus.nPowAveragingWindow = 60;
         consensus.fPowAllowMinDifficultyBlocks = true;    // facilita el arranque de signet
         consensus.fPowNoRetargeting = false;
         consensus.enforce_BIP94 = false;
@@ -622,8 +622,8 @@ public:
         consensus.fPowNoRetargeting = true;
         consensus.nSubsidyInitial          = 50 * COIN;
 
-        consensus.nPowTargetTimespan = 45; // irrelevante con no-retarget, pero coherente
         consensus.nPowTargetSpacing = 45;  // Adonai: 45 s por bloque
+        consensus.nPowAveragingWindow = 60;
 
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;

--- a/src/pow.h
+++ b/src/pow.h
@@ -28,7 +28,6 @@ class arith_uint256;
 std::optional<arith_uint256> DeriveTarget(unsigned int nBits, const uint256 pow_limit);
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader* pblock, const Consensus::Params&);
-unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(const CBlockHeader& block, const Consensus::Params& params);

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -64,8 +64,7 @@ FUZZ_TARGET(pow, .init = initialize_pow)
         }
         {
             (void)GetBlockProof(current_block);
-            (void)CalculateNextWorkRequired(&current_block, fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(0, std::numeric_limits<int64_t>::max()), consensus_params);
-            if (current_block.nHeight != std::numeric_limits<int>::max() && current_block.nHeight - (consensus_params.DifficultyAdjustmentInterval() - 1) >= 0) {
+            if (current_block.pprev != nullptr) {
                 (void)GetNextWorkRequired(&current_block, &(*block_header), consensus_params);
             }
         }

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -13,21 +13,21 @@
 BOOST_FIXTURE_TEST_SUITE(pow_tests, BasicTestingSetup)
 
 // Simulate faster blocks (higher hash rate) and ensure difficulty increases
-// and stabilizes once block intervals match the target again.
+// and stabilizes once block times match the target again.
 BOOST_AUTO_TEST_CASE(difficulty_converges_up)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::MAIN);
     const Consensus::Params& params = chainParams->GetConsensus();
 
-    const int interval = params.DifficultyAdjustmentInterval();
-    std::vector<CBlockIndex> chain(interval * 2 + 1);
+    const int window = params.DifficultyAdjustmentInterval();
+    std::vector<CBlockIndex> chain(window * 2 + 1);
     chain[0].nHeight = 0;
     chain[0].nTime = 0;
     chain[0].nBits = chainParams->GenesisBlock().nBits;
 
-    // First interval: blocks arrive twice as fast as the target spacing.
+    // First window: blocks arrive twice as fast as the target spacing.
     const int64_t fast_spacing = params.nPowTargetSpacing / 2;
-    for (int i = 1; i <= interval; ++i) {
+    for (int i = 1; i <= window; ++i) {
         CBlockHeader header;
         header.nTime = chain[i - 1].GetBlockTime() + fast_spacing;
         chain[i].pprev = &chain[i - 1];
@@ -36,11 +36,11 @@ BOOST_AUTO_TEST_CASE(difficulty_converges_up)
         chain[i].nBits = GetNextWorkRequired(&chain[i - 1], &header, params);
     }
 
-    unsigned int first_adjust = chain[interval].nBits;
+    unsigned int first_adjust = chain[window].nBits;
     BOOST_CHECK_LT(first_adjust, chain[0].nBits); // harder difficulty
 
-    // Second interval: assume block production now matches the target spacing.
-    for (int i = interval + 1; i < static_cast<int>(chain.size()); ++i) {
+    // Subsequent blocks: assume production now matches the target spacing.
+    for (int i = window + 1; i < static_cast<int>(chain.size()); ++i) {
         CBlockHeader header;
         header.nTime = chain[i - 1].GetBlockTime() + params.nPowTargetSpacing;
         chain[i].pprev = &chain[i - 1];
@@ -54,21 +54,21 @@ BOOST_AUTO_TEST_CASE(difficulty_converges_up)
 }
 
 // Simulate slower blocks (lower hash rate) and ensure difficulty decreases
-// and stabilizes when the interval normalizes.
+// and stabilizes when the spacing normalizes.
 BOOST_AUTO_TEST_CASE(difficulty_converges_down)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::MAIN);
     const Consensus::Params& params = chainParams->GetConsensus();
 
-    const int interval = params.DifficultyAdjustmentInterval();
-    std::vector<CBlockIndex> chain(interval * 2 + 1);
+    const int window = params.DifficultyAdjustmentInterval();
+    std::vector<CBlockIndex> chain(window * 2 + 1);
     chain[0].nHeight = 0;
     chain[0].nTime = 0;
     chain[0].nBits = chainParams->GenesisBlock().nBits;
 
-    // First interval: blocks arrive at half the target rate.
+    // Initial phase: blocks arrive at half the target rate.
     const int64_t slow_spacing = params.nPowTargetSpacing * 2;
-    for (int i = 1; i <= interval; ++i) {
+    for (int i = 1; i <= window; ++i) {
         CBlockHeader header;
         header.nTime = chain[i - 1].GetBlockTime() + slow_spacing;
         chain[i].pprev = &chain[i - 1];
@@ -77,11 +77,11 @@ BOOST_AUTO_TEST_CASE(difficulty_converges_down)
         chain[i].nBits = GetNextWorkRequired(&chain[i - 1], &header, params);
     }
 
-    unsigned int first_adjust = chain[interval].nBits;
+    unsigned int first_adjust = chain[window].nBits;
     BOOST_CHECK_GT(first_adjust, chain[0].nBits); // easier difficulty
 
-    // Second interval with normal spacing.
-    for (int i = interval + 1; i < static_cast<int>(chain.size()); ++i) {
+    // Subsequent blocks with normal spacing.
+    for (int i = window + 1; i < static_cast<int>(chain.size()); ++i) {
         CBlockHeader header;
         header.nTime = chain[i - 1].GetBlockTime() + params.nPowTargetSpacing;
         chain[i].pprev = &chain[i - 1];


### PR DESCRIPTION
## Summary
- switch PoW difficulty retarget to per-block LWMA algorithm
- adapt consensus params and tests to LWMA window
- document new LWMA-based difficulty algorithm

## Testing
- `cmake -GNinja ..`
- `ninja test_adonai` *(fails: build stopped - interrupted after compiling)*

------
https://chatgpt.com/codex/tasks/task_e_68b3443600a4832dbcdbc98f582b1c33