### PR TITLE
Guard LWMA difficulty against short chains

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -47,7 +47,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     const int64_t T = params.nPowTargetSpacing;
 
     // Not enough blocks for LWMA
-    if (pindexLast == nullptr || pindexLast->nHeight + 1 < N) {
+    if (pindexLast == nullptr || pindexLast->nHeight + 1 <= N) {
         const unsigned int pow_limit = UintToArith256(params.powLimit).GetCompact();
         if (pblock) {
             const_cast<CBlockHeader*>(pblock)->nBits = pow_limit;
@@ -63,6 +63,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     const CBlockIndex* block = pindexLast;
 
     for (int64_t i = 1; i <= N; ++i) {
+        if (!block->pprev) break;
         int64_t solvetime = block->GetBlockTime() - block->pprev->GetBlockTime();
         solvetime = std::clamp<int64_t>(solvetime, -6 * T, 6 * T);
         weighted_times += solvetime * i;


### PR DESCRIPTION
## Summary
- Prevent LWMA from running when chain has ≤ N blocks and fall back to powLimit
- Stop iteration before dereferencing a null genesis block
- Test difficulty calculation with exactly N blocks

## Testing
- `cmake -S . -B build -GNinja -DBUILD_TESTS=ON -DBUILD_ADONAI_BIN=OFF -DBUILD_DAEMON=OFF -DBUILD_GUI=OFF -DBUILD_CLI=OFF -DBUILD_TX=OFF -DBUILD_UTIL=OFF -DENABLE_WALLET=OFF -DBUILD_WALLET_TOOL=OFF`
- `cmake --build build --target test_adonai`
- `./build/bin/test_adonai --run_test=pow_tests/no_dereference_with_exact_window`


------
https://chatgpt.com/codex/tasks/task_e_68b353bdff64832d8b2a6d27fee2e2ea