### PR TITLE
Add proof-of-work hash test for genesis block

### DIFF
--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -104,10 +104,11 @@ BOOST_AUTO_TEST_CASE(genesis_block_pow)
     const CBlockHeader& header = genesis.GetBlockHeader();
     const uint256 hash = header.GetHash();
 
-    BOOST_CHECK(CheckProofOfWork(hash, header.nBits, params));
-    BOOST_CHECK_EQUAL(
-        CheckProofOfWork(hash, header.nBits, params),
-        CheckProofOfWork(header, params));
+    const bool direct = CheckProofOfWork(hash, header.nBits, params);
+    const bool via_header = CheckProofOfWork(header, params);
+
+    BOOST_CHECK(direct);
+    BOOST_CHECK_EQUAL(direct, via_header);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- test: verify proof-of-work for the genesis block by comparing GetHash() with both CheckProofOfWork paths

## Testing
- `cmake -S . -B build -GNinja -DBUILD_TESTS=ON -DBUILD_GUI=OFF -DWITH_QRENCODE=OFF -DWITH_USDT=OFF`
- `ninja -C build test_adonai`
- `./build/bin/test_adonai --run_test=pow_tests` *(fails: memory access violation in difficulty_converges_up)*

------
https://chatgpt.com/codex/tasks/task_e_68b3546fac98832d906fef535f5b8d0a