### PR TITLE
Use halving interval constant in subsidy comment

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1946,7 +1946,8 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
         return 0;
 
     CAmount nSubsidy = consensusParams.nSubsidyInitial;
-    // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
+    // Subsidy is cut in half every consensusParams.nSubsidyHalvingInterval blocks
+    // (1,000,000 for this chain).
     nSubsidy >>= halvings;
     return nSubsidy;
 }


### PR DESCRIPTION
## Summary
- reference `nSubsidyHalvingInterval` rather than hard-coded numbers in block subsidy comment

## Testing
- `cmake -S . -B build`
- `ctest --test-dir build` *(fails: Unable to find executable)*

------
https://chatgpt.com/codex/tasks/task_e_68b35ce0fb60832db4fd6c2888f1703f