### PR TITLE
Implement gradual PoW spacing ramp

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -151,14 +151,18 @@ public:
         // PoW BLAKE3: objetivo máximo más estricto para mayor seguridad
         consensus.powLimit = uint256{"00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
 
-        consensus.nPowTargetSpacingV1      = 120;     // arranque seguro
         consensus.nPowTargetSpacing = 45; // time between blocks
         consensus.nPowAveragingWindow = 60; // LWMA window
+        consensus.powSpacingRamps = {
+            {0,    120},
+            {3000, 90},
+            {6000, 60},
+            {10000, 45},
+        };
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
 
-        consensus.nPowSpacingSwitchHeight  = 10000;   // altura para cambio
         consensus.nSubsidyInitial          = 50 * COIN;
         consensus.nCoinbaseMaturity        = 200;     // ≈ 6h al inicio
 

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -27,9 +27,9 @@ BOOST_AUTO_TEST_CASE(difficulty_converges_up)
     chain[0].nBits = chainParams->GenesisBlock().nBits;
 
     // First window: blocks arrive twice as fast as the target spacing.
-    const int64_t fast_spacing = params.nPowTargetSpacing / 2;
     for (int i = 1; i <= window; ++i) {
         CBlockHeader header;
+        int64_t fast_spacing = params.GetTargetSpacing(i) / 2;
         header.nTime = chain[i - 1].GetBlockTime() + fast_spacing;
         chain[i].pprev = &chain[i - 1];
         chain[i].nHeight = i;
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(difficulty_converges_up)
     // Subsequent blocks: assume production now matches the target spacing.
     for (int i = window + 1; i < static_cast<int>(chain.size()); ++i) {
         CBlockHeader header;
-        header.nTime = chain[i - 1].GetBlockTime() + params.nPowTargetSpacing;
+        header.nTime = chain[i - 1].GetBlockTime() + params.GetTargetSpacing(i);
         chain[i].pprev = &chain[i - 1];
         chain[i].nHeight = i;
         chain[i].nTime = header.nTime;
@@ -68,9 +68,9 @@ BOOST_AUTO_TEST_CASE(difficulty_converges_down)
     chain[0].nBits = chainParams->GenesisBlock().nBits;
 
     // Initial phase: blocks arrive at half the target rate.
-    const int64_t slow_spacing = params.nPowTargetSpacing * 2;
     for (int i = 1; i <= window; ++i) {
         CBlockHeader header;
+        int64_t slow_spacing = params.GetTargetSpacing(i) * 2;
         header.nTime = chain[i - 1].GetBlockTime() + slow_spacing;
         chain[i].pprev = &chain[i - 1];
         chain[i].nHeight = i;
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(difficulty_converges_down)
     // Subsequent blocks with normal spacing.
     for (int i = window + 1; i < static_cast<int>(chain.size()); ++i) {
         CBlockHeader header;
-        header.nTime = chain[i - 1].GetBlockTime() + params.nPowTargetSpacing;
+        header.nTime = chain[i - 1].GetBlockTime() + params.GetTargetSpacing(i);
         chain[i].pprev = &chain[i - 1];
         chain[i].nHeight = i;
         chain[i].nTime = header.nTime;
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(no_dereference_with_exact_window)
     for (int i = 1; i < window; ++i) {
         chain[i].pprev = &chain[i - 1];
         chain[i].nHeight = i;
-        chain[i].nTime = chain[i - 1].GetBlockTime() + params.nPowTargetSpacing;
+        chain[i].nTime = chain[i - 1].GetBlockTime() + params.GetTargetSpacing(i);
         chain[i].nBits = chainParams->GenesisBlock().nBits;
     }
 


### PR DESCRIPTION
## Summary
- Replace hard `nPowSpacingSwitchHeight` with a multi-stage spacing ramp
- Smooth difficulty transitions using height-aware LWMA
- Update tests to use dynamic target spacing schedule

## Testing
- `cmake ..`
- `make test_adonai` *(fails: build interrupted due to resource limits)*

------
https://chatgpt.com/codex/tasks/task_e_68b35c2da81c832d948b77e46eb54cd8