### PR TITLE
logging: add pow category and guard block hash debug

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -406,6 +406,9 @@ all log categories and `-loglevel=trace` will turn on all log severity levels.
 The Qt code routes `qDebug()` output to `debug.log` under category "qt": run with `-debug=qt`
 to see it.
 
+The proof-of-work hashing code logs under the `pow` category. Use `-debug=pow` to
+enable these messages and filter them easily.
+
 ### Testnet mode
 
 If you are testing multi-machine code that needs to operate across the internet,

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -185,6 +185,7 @@ static const std::map<std::string, BCLog::LogFlags, std::less<>> LOG_CATEGORIES_
     {"reindex", BCLog::REINDEX},
     {"cmpctblock", BCLog::CMPCTBLOCK},
     {"rand", BCLog::RAND},
+    {"pow", BCLog::POW},
     {"prune", BCLog::PRUNE},
     {"proxy", BCLog::PROXY},
     {"mempoolrej", BCLog::MEMPOOLREJ},

--- a/src/logging.h
+++ b/src/logging.h
@@ -94,6 +94,7 @@ namespace BCLog {
         TXRECONCILIATION = (CategoryMask{1} << 26),
         SCAN        = (CategoryMask{1} << 27),
         TXPACKAGES  = (CategoryMask{1} << 28),
+        POW         = (CategoryMask{1} << 29),
         ALL         = ~NONE,
     };
     enum class Level {

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -12,6 +12,7 @@
 #include <blake3/blake3.h>
 #include <hash.h>
 #include <tinyformat.h>
+#include <logging.h>
 
 uint256 CBlockHeader::GetHash() const
 {
@@ -26,7 +27,8 @@ uint256 CBlockHeader::GetHash() const
     blake3_hasher_finalize(&hasher, out, BLAKE3_OUT_LEN);
 
     uint256 res = uint256(std::span<const unsigned char>(out, 32));
-    LogPrintf("[POW] BLAKE3 header hash = %s\n", res.ToString());
+    // Logged under the "pow" category for filtering with -debug=pow
+    LogPrintLevel(BCLog::POW, BCLog::Level::Debug, "BLAKE3 header hash = %s\n", res.ToString());
 
     return res;
 }


### PR DESCRIPTION
## Summary
- add `pow` logging category and use it for block header hash debug output
- document how to enable `pow` logs for filtering

## Testing
- `ninja -C build test_adonai` *(fails: interrupted)*
- `./build/bin/test_adonai --catch_system_errors=no -l test_suite` *(fails: `CPubKey CKey::GetPubKey() const` assertion)*


------
https://chatgpt.com/codex/tasks/task_e_68b354771c20832dab227b305d6ab829