### PR TITLE
Fix Qt resource initialization

### DIFF
--- a/src/qt/adonai.cpp
+++ b/src/qt/adonai.cpp
@@ -497,8 +497,9 @@ int GuiMain(int argc, char* argv[])
     // Do not refer to data directory yet, this can be overridden by Intro::pickDataDirectory
 
     /// 1. Basic Qt initialization (not dependent on parameters or configuration)
-    Q_INIT_RESOURCE(bitcoin);
-    Q_INIT_RESOURCE(bitcoin_locale);
+    // Initialize Qt resources generated from adonai.qrc and adonai_locale.qrc
+    Q_INIT_RESOURCE(adonai);
+    Q_INIT_RESOURCE(adonai_locale);
 
 #if defined(QT_QPA_PLATFORM_ANDROID)
     QApplication::setAttribute(Qt::AA_DontUseNativeMenuBar);


### PR DESCRIPTION
## Summary
- use correct resource names for Qt initialization to match renamed `.qrc` files

## Testing
- `cmake -S . -B build -DBUILD_GUI=ON`
- ⚠️ `cmake --build build --target adonai-qt -j2` *(interrupted due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68b36fc07158832d9c3fc223692cd519