### PR TITLE
Log invalid header details

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2985,6 +2985,10 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
                                                            state, &pindexLast)};
     if (!processed) {
         if (state.IsInvalid()) {
+            const uint256 hash{headers.front().GetHash()};
+            LogDebug(static_cast<BCLog::LogFlags>(BCLog::NET | BCLog::VALIDATION),
+                     "invalid header %s from peer=%d: %s\n",
+                     hash.ToString(), pfrom.GetId(), state.GetRejectReason());
             MaybePunishNodeForBlock(pfrom.GetId(), state, via_compact_block, "invalid header received");
             return;
         }


### PR DESCRIPTION
## Summary
- log invalid block header hash and reject reason when discouraging peers

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Release ..`
- `make -j2 adonaid`
- `BITCOIND=/workspace/ADONAI/build/bin/adonaid BITCOINCLI=/workspace/ADONAI/build/bin/adonai-cli BITCOINUTIL=/workspace/ADONAI/build/bin/adonai-util BITCOINTX=/workspace/ADONAI/build/bin/adonai-tx BITCOINWALLET=/workspace/ADONAI/build/bin/adonai-wallet python3 test/functional/test_runner.py --nocleanup test/functional/invalid_header_log.py` *(fails: Missing SRCDIR/config)*

------
https://chatgpt.com/codex/tasks/task_e_68b494d058a4832da7e2eaa82838f245