### PR TITLE
Add headers log category

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -203,6 +203,7 @@ static const std::map<std::string, BCLog::LogFlags, std::less<>> LOG_CATEGORIES_
     {"txreconciliation", BCLog::TXRECONCILIATION},
     {"scan", BCLog::SCAN},
     {"txpackages", BCLog::TXPACKAGES},
+    {"headers", BCLog::HEADERS},
 };
 
 static const std::unordered_map<BCLog::LogFlags, std::string> LOG_CATEGORIES_BY_FLAG{

--- a/src/logging.h
+++ b/src/logging.h
@@ -95,6 +95,7 @@ namespace BCLog {
         SCAN        = (CategoryMask{1} << 27),
         TXPACKAGES  = (CategoryMask{1} << 28),
         POW         = (CategoryMask{1} << 29),
+        HEADERS     = (CategoryMask{1} << 30),
         ALL         = ~NONE,
     };
     enum class Level {


### PR DESCRIPTION
## Summary
- extend `BCLog::LogFlags` with new `HEADERS` bit
- expose `headers` category in `LOG_CATEGORIES_BY_STR`

## Testing
- `cmake -S . -B build -GNinja -DBUILD_GUI=ON`
- `ninja -C build src/util/CMakeFiles/adonai_util.dir/__/logging.cpp.o`


------
https://chatgpt.com/codex/tasks/task_e_68b4a44a3400832d9a5d64bbe1dc2aef