### PR TITLE
Fix logging for multi-category flags

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -254,9 +254,15 @@ static std::string LogCategoryToStr(BCLog::LogFlags category)
     if (category == BCLog::ALL) {
         return "all";
     }
-    auto it = LOG_CATEGORIES_BY_FLAG.find(category);
-    assert(it != LOG_CATEGORIES_BY_FLAG.end());
-    return it->second;
+    std::string ret;
+    for (const auto& [name, flag] : LOG_CATEGORIES_BY_STR) {
+        if ((category & flag) != 0) {
+            if (!ret.empty()) ret += ",";
+            ret += name;
+        }
+    }
+    assert(!ret.empty());
+    return ret;
 }
 
 static std::optional<BCLog::Level> GetLogLevel(std::string_view level_str)

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -171,6 +171,20 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros, LogSetup)
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
 
+BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros_MultiCategory, LogSetup)
+{
+    LogDebug(static_cast<BCLog::LogFlags>(BCLog::NET | BCLog::VALIDATION), "foo11: %s", "bar11");
+    std::ifstream file{tmp_log_path};
+    std::vector<std::string> log_lines;
+    for (std::string log; std::getline(file, log);) {
+        log_lines.push_back(log);
+    }
+    std::vector<std::string> expected = {
+        "[net,validation] foo11: bar11",
+    };
+    BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
+}
+
 BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros_CategoryName, LogSetup)
 {
     LogInstance().EnableCategory(BCLog::LogFlags::ALL);


### PR DESCRIPTION
## Summary
- Handle combined log categories instead of asserting on unknown flags
- Test logging with multiple categories enabled

## Testing
- `ninja -C build test_adonai` *(fails: build interrupted due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b1f96e90832d97179ab736da7817