### PR TITLE
Align genesis difficulty with powLimit

### DIFF
--- a/GENESIS.adonai.txt
+++ b/GENESIS.adonai.txt
@@ -9,9 +9,9 @@ Suministro máximo: 100,915,200 ADO
 
 Genesis:
   time   = 1754122572
-  nonce  = 2445534
-  nBits  = 0x1e0ffff0
-  hash   = 00000be2948953149109fd556f8f0a327e450a52a3d9a411c88e5e7ad8eae0d1
+  nonce  = 119040
+  nBits  = 0x1e0fffff
+  hash   = 000008358709fae09230a75838c2c30b15eff28790d530c2d8b0fd5739e0cd06
   merkle = 3c27610446c91576f0f18fa4e758b72565f678ae063346fe6d271d6d850783b6
 
 Address formats:

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -207,14 +207,14 @@ public:
 
         genesis = CreateGenesisBlock(
             /* nTime */ 1754122572,
-            /* nNonce */ 2445534,
-            /* nBits */ 0x1e0ffff0,
+            /* nNonce */ 119040,
+            /* nBits */ 0x1e0fffff,
             /* nVersion */ 1,
             /* genesisReward */ 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
 
         // Asegura tus asserts (usa el formato de tu uint256, aquí es con llaves):
-        assert(consensus.hashGenesisBlock == uint256{"00000be2948953149109fd556f8f0a327e450a52a3d9a411c88e5e7ad8eae0d1"});
+        assert(consensus.hashGenesisBlock == uint256{"000008358709fae09230a75838c2c30b15eff28790d530c2d8b0fd5739e0cd06"});
         assert(genesis.hashMerkleRoot == uint256{"3c27610446c91576f0f18fa4e758b72565f678ae063346fe6d271d6d850783b6"});
 
 


### PR DESCRIPTION
## Summary
- Align mainnet genesis nBits with consensus powLimit
- Re-mine genesis block and update hash, nonce and docs

## Testing
- `cmake -S . -B build`
- `cmake --build build --target adonai`

------
https://chatgpt.com/codex/tasks/task_e_68b4c8ad63d0832d84876f9d6eeaff70