### PR TITLE
feat(frontend): add Zustand global store

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "i18next": "^25.4.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-i18next": "^15.7.3"
+        "react-i18next": "^15.7.3",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1463,7 +1464,7 @@
       "version": "19.1.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1999,7 +2000,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3626,6 +3627,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "i18next": "^25.4.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-i18next": "^15.7.3"
+    "react-i18next": "^15.7.3",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+import { devtools, persist } from 'zustand/middleware'
+import { createNodeSlice } from './node'
+import { createWalletSlice } from './wallet'
+import { createMiningSlice } from './mining'
+import { createSettingsSlice } from './settings'
+import { logger } from './middleware/logger'
+import type { AppState } from './types'
+
+export const useAppStore = create<AppState>()(
+  logger(
+    devtools(
+      persist(
+        (set, get, api) => ({
+          ...createNodeSlice(set, get, api),
+          ...createWalletSlice(set, get, api),
+          ...createMiningSlice(set, get, api),
+          ...createSettingsSlice(set, get, api),
+        }),
+        { name: 'app-state' },
+      ),
+    ),
+  ),
+)

--- a/frontend/src/store/middleware/logger.ts
+++ b/frontend/src/store/middleware/logger.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { StateCreator } from 'zustand'
+
+export const logger =
+  <T extends object>(
+    config: StateCreator<T, any, any>,
+  ): StateCreator<T, any, any> =>
+  (set, get, api) =>
+    config(
+      (partial, replace) => {
+        const previous = get()
+        set(partial as any, replace as any)
+        console.log('[store]', { previous, next: get() })
+      },
+      get,
+      api,
+    )

--- a/frontend/src/store/mining.ts
+++ b/frontend/src/store/mining.ts
@@ -1,0 +1,6 @@
+import type { AppSlice, MiningSlice } from './types'
+
+export const createMiningSlice: AppSlice<MiningSlice> = (set) => ({
+  isMining: false,
+  toggleMining: () => set((state) => ({ isMining: !state.isMining })),
+})

--- a/frontend/src/store/node.ts
+++ b/frontend/src/store/node.ts
@@ -1,0 +1,6 @@
+import type { AppSlice, NodeSlice } from './types'
+
+export const createNodeSlice: AppSlice<NodeSlice> = (set) => ({
+  height: 0,
+  setHeight: (height) => set({ height }),
+})

--- a/frontend/src/store/settings.ts
+++ b/frontend/src/store/settings.ts
@@ -1,0 +1,6 @@
+import type { AppSlice, SettingsSlice } from './types'
+
+export const createSettingsSlice: AppSlice<SettingsSlice> = (set) => ({
+  darkMode: false,
+  toggleDarkMode: () => set((state) => ({ darkMode: !state.darkMode })),
+})

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -1,0 +1,24 @@
+import type { StateCreator } from 'zustand'
+
+export interface NodeSlice {
+  height: number
+  setHeight: (height: number) => void
+}
+
+export interface WalletSlice {
+  balance: number
+  setBalance: (balance: number) => void
+}
+
+export interface MiningSlice {
+  isMining: boolean
+  toggleMining: () => void
+}
+
+export interface SettingsSlice {
+  darkMode: boolean
+  toggleDarkMode: () => void
+}
+
+export type AppState = NodeSlice & WalletSlice & MiningSlice & SettingsSlice
+export type AppSlice<T> = StateCreator<AppState, [], [], T>

--- a/frontend/src/store/wallet.ts
+++ b/frontend/src/store/wallet.ts
@@ -1,0 +1,6 @@
+import type { AppSlice, WalletSlice } from './types'
+
+export const createWalletSlice: AppSlice<WalletSlice> = (set) => ({
+  balance: 0,
+  setBalance: (balance) => set({ balance }),
+})


### PR DESCRIPTION
## Summary
- add Zustand with devtools, persist, and logging middleware
- define node, wallet, mining, and settings slices for global state

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b768656540832da3ad6e5ab681d4a6