### PR TITLE
feat(frontend): add wallet onboarding flow

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "i18next": "^25.4.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-i18next": "^15.7.3"
+        "react-i18next": "^15.7.3",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1463,7 +1464,7 @@
       "version": "19.1.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1999,7 +2000,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3626,6 +3627,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "i18next": "^25.4.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-i18next": "^15.7.3"
+    "react-i18next": "^15.7.3",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,13 +1,20 @@
 import { useTranslation } from 'react-i18next'
+import Onboarding from '@/features/onboarding'
 import { useTheme } from '@/lib/theme'
+import { useWalletStore } from '@/store/wallet'
 import './App.css'
 
 export default function App() {
   const { t, i18n } = useTranslation()
   const { theme, toggle } = useTheme()
+  const isLoaded = useWalletStore((s) => s.isLoaded)
 
   const switchLang = () => {
     i18n.changeLanguage(i18n.language === 'en' ? 'es' : 'en')
+  }
+
+  if (!isLoaded) {
+    return <Onboarding />
   }
 
   return (

--- a/frontend/src/features/onboarding/Onboarding.tsx
+++ b/frontend/src/features/onboarding/Onboarding.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useWalletStore } from '@/store/wallet'
+import './onboarding.css'
+
+const WORDS = [
+  'apple',
+  'banana',
+  'cherry',
+  'dog',
+  'eagle',
+  'frog',
+  'grape',
+  'house',
+  'ice',
+  'jungle',
+  'kite',
+  'lemon',
+  'moon',
+  'night',
+  'orange',
+  'pumpkin',
+  'queen',
+  'rocket',
+  'sun',
+  'tree',
+  'umbrella',
+  'violin',
+  'whale',
+  'xray',
+  'yellow',
+  'zebra',
+]
+
+function generateSeed() {
+  return Array.from(
+    { length: 12 },
+    () => WORDS[Math.floor(Math.random() * WORDS.length)],
+  )
+}
+
+enum Step {
+  CHOOSE,
+  SHOW,
+  VERIFY,
+  IMPORT,
+}
+
+export default function Onboarding() {
+  const { t } = useTranslation()
+  const loadWallet = useWalletStore((s) => s.loadWallet)
+
+  const [step, setStep] = useState<Step>(Step.CHOOSE)
+  const [seed, setSeed] = useState<string[]>([])
+  const [input, setInput] = useState('')
+
+  const handleCreate = () => {
+    const words = generateSeed()
+    setSeed(words)
+    setStep(Step.SHOW)
+  }
+
+  const handleVerify = () => {
+    const words = input.trim().split(/\s+/)
+    if (words.join(' ') === seed.join(' ')) {
+      loadWallet(seed)
+    } else {
+      alert(t('seedMismatch'))
+    }
+  }
+
+  const handleImport = () => {
+    const words = input.trim().split(/\s+/)
+    if (words.length >= 12) {
+      loadWallet(words)
+    } else {
+      alert(t('seedInvalid'))
+    }
+  }
+
+  return (
+    <div className="onboarding">
+      {step === Step.CHOOSE && (
+        <div>
+          <h2>{t('onboardingTitle')}</h2>
+          <button onClick={handleCreate}>{t('createWallet')}</button>
+          <button onClick={() => setStep(Step.IMPORT)}>
+            {t('loadWallet')}
+          </button>
+        </div>
+      )}
+
+      {step === Step.SHOW && (
+        <div>
+          <h2>{t('seedTitle')}</h2>
+          <p className="seed" aria-label={t('seedLabel')}>
+            {seed.join(' ')}
+          </p>
+          <button onClick={() => setStep(Step.VERIFY)}>
+            {t('confirmSeed')}
+          </button>
+        </div>
+      )}
+
+      {step === Step.VERIFY && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleVerify()
+          }}
+        >
+          <h2>{t('verifySeed')}</h2>
+          <label htmlFor="verify">{t('seedLabel')}</label>
+          <textarea
+            id="verify"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            required
+          />
+          <button type="submit">{t('submit')}</button>
+        </form>
+      )}
+
+      {step === Step.IMPORT && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleImport()
+          }}
+        >
+          <h2>{t('loadWallet')}</h2>
+          <label htmlFor="seed">{t('seedLabel')}</label>
+          <textarea
+            id="seed"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            required
+          />
+          <button type="submit">{t('submit')}</button>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/onboarding/index.ts
+++ b/frontend/src/features/onboarding/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Onboarding'

--- a/frontend/src/features/onboarding/onboarding.css
+++ b/frontend/src/features/onboarding/onboarding.css
@@ -1,0 +1,24 @@
+.onboarding {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.onboarding .seed {
+  word-break: break-word;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+}
+
+.onboarding textarea {
+  width: 100%;
+  min-height: 6rem;
+}
+
+.onboarding button {
+  padding: 0.5rem 1rem;
+  margin-top: 0.5rem;
+}

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -2,8 +2,36 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
 const resources = {
-  en: { translation: { welcome: 'Welcome' } },
-  es: { translation: { welcome: 'Bienvenido' } },
+  en: {
+    translation: {
+      welcome: 'Welcome',
+      onboardingTitle: 'Onboarding',
+      createWallet: 'Create Wallet',
+      loadWallet: 'Load Wallet',
+      seedTitle: 'Your Seed',
+      seedLabel: 'Seed',
+      confirmSeed: "I've written it down",
+      verifySeed: 'Verify Seed',
+      submit: 'Submit',
+      seedMismatch: 'Seed does not match',
+      seedInvalid: 'Seed is invalid',
+    },
+  },
+  es: {
+    translation: {
+      welcome: 'Bienvenido',
+      onboardingTitle: 'Inicio',
+      createWallet: 'Crear Billetera',
+      loadWallet: 'Cargar Billetera',
+      seedTitle: 'Tu Semilla',
+      seedLabel: 'Semilla',
+      confirmSeed: 'Ya la anoté',
+      verifySeed: 'Verificar Semilla',
+      submit: 'Enviar',
+      seedMismatch: 'La semilla no coincide',
+      seedInvalid: 'Semilla inválida',
+    },
+  },
 }
 
 i18n.use(initReactI18next).init({

--- a/frontend/src/store/wallet.ts
+++ b/frontend/src/store/wallet.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface WalletState {
+  seed: string[]
+  isLoaded: boolean
+  loadWallet: (seed: string[]) => void
+  clear: () => void
+}
+
+export const useWalletStore = create<WalletState>()(
+  persist(
+    (set) => ({
+      seed: [],
+      isLoaded: false,
+      loadWallet: (seed) => set({ seed, isLoaded: true }),
+      clear: () => set({ seed: [], isLoaded: false }),
+    }),
+    {
+      name: 'wallet',
+      partialize: (state) => ({ seed: state.seed }),
+    },
+  ),
+)


### PR DESCRIPTION
## Summary
- implement onboarding flow for creating or loading a wallet
- persist wallet seed with Zustand store
- add translations and styles for onboarding screens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76951b700832dab3573af91c598bc