### PR TITLE
feat: add formatting helpers and global notifications

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -13,11 +13,9 @@ export default function App() {
   const { t, i18n } = useTranslation()
   const { theme, toggle } = useTheme()
   const isLoaded = useWalletStore((s) => s.isLoaded)
-  const [page, setPage] = useState<'dashboard' | 'wallet' | 'mining'>(
-  const [page, setPage] = useState<'dashboard' | 'wallet' | 'network'>(
-
-    'dashboard',
-  )
+  const [page, setPage] = useState<
+    'dashboard' | 'wallet' | 'mining' | 'network'
+  >('dashboard')
 
   const switchLang = () => {
     i18n.changeLanguage(i18n.language === 'en' ? 'es' : 'en')
@@ -47,20 +45,13 @@ export default function App() {
         <button onClick={() => setPage('mining')} aria-label="mining">
           {t('mining')}
         </button>
-      </nav>
-      {page === 'dashboard' ? (
-        <Dashboard />
-      ) : page === 'wallet' ? (
-        <Wallet />
-      ) : (
-        <Mining />
-      )}
         <button onClick={() => setPage('network')} aria-label="network">
           {t('network')}
         </button>
       </nav>
       {page === 'dashboard' && <Dashboard />}
       {page === 'wallet' && <Wallet />}
+      {page === 'mining' && <Mining />}
       {page === 'network' && <Network />}
     </div>
   )

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,27 @@
+import { Component, ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+interface State {
+  hasError: boolean
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: unknown) {
+    console.error('ErrorBoundary caught:', error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Something went wrong.</div>
+    }
+    return this.props.children
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,3 +22,24 @@ html:not(.dark) {
   background-color: #ffffff;
   color: #213547;
 }
+
+.notifications {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.notification {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  background-color: #333;
+  color: #fff;
+}
+
+html:not(.dark) .notification {
+  background-color: #e1e1e1;
+  color: #213547;
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,22 @@
+export function formatCurrency(value: number, currency = 'ADO'): string {
+  return `${value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })} ${currency}`
+}
+
+export function formatTime(value: number | Date): string {
+  const date = typeof value === 'number' ? new Date(value * 1000) : value
+  return date.toLocaleString()
+}
+
+export function formatHash(value: number): string {
+  const units = ['H', 'KH', 'MH', 'GH', 'TH', 'PH'] as const
+  let n = value
+  let i = 0
+  while (n >= 1000 && i < units.length - 1) {
+    n /= 1000
+    i++
+  }
+  return `${n.toFixed(2)} ${units[i]}`
+}

--- a/frontend/src/lib/notifications.tsx
+++ b/frontend/src/lib/notifications.tsx
@@ -1,0 +1,55 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from 'react'
+
+interface Notification {
+  id: number
+  message: string
+}
+
+interface NotificationsContextValue {
+  notify: (message: string) => void
+}
+
+const NotificationsContext = createContext<
+  NotificationsContextValue | undefined
+>(undefined)
+// eslint-disable-next-line react-refresh/only-export-components
+export function useNotifications() {
+  const ctx = useContext(NotificationsContext)
+  if (!ctx) {
+    throw new Error(
+      'useNotifications must be used within NotificationsProvider',
+    )
+  }
+  return ctx
+}
+
+export function NotificationsProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<Notification[]>([])
+
+  const notify = useCallback((message: string) => {
+    const id = Date.now()
+    setItems((prev) => [...prev, { id, message }])
+    setTimeout(() => {
+      setItems((prev) => prev.filter((n) => n.id !== id))
+    }, 3000)
+  }, [])
+
+  return (
+    <NotificationsContext.Provider value={{ notify }}>
+      {children}
+      <div className="notifications">
+        {items.map((n) => (
+          <div key={n.id} className="notification">
+            {n.message}
+          </div>
+        ))}
+      </div>
+    </NotificationsContext.Provider>
+  )
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,12 +3,18 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import './lib/i18n'
 import { ThemeProvider } from '@/lib/theme'
+import { NotificationsProvider } from '@/lib/notifications'
+import { ErrorBoundary } from '@/components/ErrorBoundary'
 import App from '@/app/App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ThemeProvider>
-      <App />
+      <NotificationsProvider>
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
+      </NotificationsProvider>
     </ThemeProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add helpers to format currency, time, and hash rates
- introduce global error boundary and notification provider
- wire utilities into React root and add basic styles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c21da778832d9a4ce21bb211ea24