### PR TITLE
feat: unify WebSocket events and miner state

### DIFF
--- a/frontend/src/hooks/useMiner.ts
+++ b/frontend/src/hooks/useMiner.ts
@@ -12,12 +12,17 @@ export function useMiner() {
   )
 
   useEffect(() => {
-    const ws = new WebSocket('ws://localhost:8080/miner')
+    const ws = new WebSocket('ws://localhost:8080/ws')
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ subscribe: 'miner' }))
+    }
     ws.onmessage = (e) => {
       try {
-        const data = JSON.parse(e.data)
-        if (data.isMining !== undefined) setIsMining(data.isMining)
-        if (data.hashrate !== undefined) setMinerHashrate(data.hashrate)
+        const { event, data } = JSON.parse(e.data)
+        if (event === 'miner') {
+          if (data.isMining !== undefined) setIsMining(data.isMining)
+          if (data.hashrate !== undefined) setMinerHashrate(data.hashrate)
+        }
       } catch (err) {
         console.error('miner ws error', err)
       }

--- a/gateway/src/index.js
+++ b/gateway/src/index.js
@@ -117,6 +117,20 @@ wss.on('connection', (ws) => {
   });
 });
 
+// Periodic miner state broadcast
+async function pollMiner() {
+  try {
+    const [info] = await rpcClient.command([{ method: 'getmininginfo', parameters: [] }]);
+    const isMining = info.generating || info.generate || false;
+    const hashrate = info.hashespersec || info.networkhashps || 0;
+    broadcast('miner', { isMining, hashrate });
+  } catch (e) {
+    // swallow errors to avoid noisy logs when daemon is unavailable
+  }
+}
+pollMiner();
+setInterval(pollMiner, 5000);
+
 // ZMQ subscriptions for block/tx events
 async function initZmq() {
   const sock = new zmq.Subscriber();


### PR DESCRIPTION
## Summary
- broadcast miner state through WebSocket and unify payload format
- subscribe to miner, newBlock, and newTx events in frontend
- adapt dashboard and miner hook to new message structure

## Testing
- `cd gateway && npm test`
- `cd frontend && npm test`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7c8723938832db58f7f0c31d46765