### PR TITLE
feat: integrate wallet and mining with RPC

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@scure/bip39": "^2.0.0",
         "i18next": "^25.4.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -1040,6 +1041,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.0.tgz",
+      "integrity": "sha512-h8VUBlE8R42+XIDO229cgisD287im3kdY6nbNZJFjc6ZvKIXPYXe6Vc/t+kyjFdMFyt5JpapzTsEg8n63w5/lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1391,6 +1404,28 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.0.tgz",
+      "integrity": "sha512-F2Tza4KyTSFO/13JymY6a6UHfSLzx0YGbkQGz7wjGx2BYJLyG/qXELKnFFsDfeIK+WfV2v2+5XOQftvL4d8RBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.0",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@scure/bip39": "^2.0.0",
     "i18next": "^25.4.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/frontend/src/features/onboarding/Onboarding.tsx
+++ b/frontend/src/features/onboarding/Onboarding.tsx
@@ -1,43 +1,9 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useWalletStore } from '@/store/wallet'
+import { generateMnemonic, validateMnemonic } from '@scure/bip39'
+import { english } from '@scure/bip39/wordlists/english'
 import './onboarding.css'
-
-const WORDS = [
-  'apple',
-  'banana',
-  'cherry',
-  'dog',
-  'eagle',
-  'frog',
-  'grape',
-  'house',
-  'ice',
-  'jungle',
-  'kite',
-  'lemon',
-  'moon',
-  'night',
-  'orange',
-  'pumpkin',
-  'queen',
-  'rocket',
-  'sun',
-  'tree',
-  'umbrella',
-  'violin',
-  'whale',
-  'xray',
-  'yellow',
-  'zebra',
-]
-
-function generateSeed() {
-  return Array.from(
-    { length: 12 },
-    () => WORDS[Math.floor(Math.random() * WORDS.length)],
-  )
-}
 
 enum Step {
   CHOOSE,
@@ -55,7 +21,8 @@ export default function Onboarding() {
   const [input, setInput] = useState('')
 
   const handleCreate = () => {
-    const words = generateSeed()
+    const mnemonic = generateMnemonic(english, 128)
+    const words = mnemonic.split(' ')
     setSeed(words)
     setStep(Step.SHOW)
   }
@@ -71,7 +38,7 @@ export default function Onboarding() {
 
   const handleImport = () => {
     const words = input.trim().split(/\s+/)
-    if (words.length >= 12) {
+    if (validateMnemonic(words.join(' '), english)) {
       loadWallet(words)
     } else {
       alert(t('seedInvalid'))

--- a/frontend/src/features/wallet/History.tsx
+++ b/frontend/src/features/wallet/History.tsx
@@ -1,11 +1,31 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useAppStore } from '@/store'
 import { useTranslation } from 'react-i18next'
 
 export default function History() {
   const { t } = useTranslation()
-  const transactions = useAppStore((s) => s.transactions)
+  const { transactions, setTransactions } = useAppStore((s) => ({
+    transactions: s.transactions,
+    setTransactions: s.setTransactions,
+  }))
   const [filter, setFilter] = useState('')
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const res = await fetch('/api/listtransactions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '[]',
+        })
+        const data = await res.json()
+        if (Array.isArray(data.result))
+          setTransactions(data.result.map((tx: any) => tx.txid))
+      } catch (err) {
+        console.error('listtransactions failed', err)
+      }
+    })()
+  }, [setTransactions])
 
   const filtered = transactions.filter((tx) => tx.includes(filter))
 

--- a/frontend/src/features/wallet/Receive.tsx
+++ b/frontend/src/features/wallet/Receive.tsx
@@ -1,10 +1,27 @@
+import { useEffect } from 'react'
 import { useAppStore } from '@/store'
 import QRCode from 'react-qr-code'
 import { useTranslation } from 'react-i18next'
 
 export default function Receive() {
   const { t } = useTranslation()
-  const address = useAppStore((s) => s.address)
+  const { address, setAddress } = useAppStore((s) => ({
+    address: s.address,
+    setAddress: s.setAddress,
+  }))
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const res = await fetch('/api/getnewaddress', { method: 'POST' })
+        const data = await res.json()
+        if (data.result) setAddress(data.result)
+      } catch (err) {
+        console.error('getnewaddress failed', err)
+      }
+    })()
+  }, [setAddress])
+
   return (
     <div className="receive">
       <p>

--- a/frontend/src/features/wallet/Send.tsx
+++ b/frontend/src/features/wallet/Send.tsx
@@ -4,36 +4,57 @@ import { useAppStore } from '@/store'
 
 export default function Send() {
   const { t } = useTranslation()
-  const { balance, transactions, utxos, setTransactions, setBalance } =
-    useAppStore((s) => ({
-      balance: s.balance,
-      transactions: s.transactions,
-      utxos: s.utxos,
-      setTransactions: s.setTransactions,
-      setBalance: s.setBalance,
-    }))
+  const { balance, setTransactions, setBalance } = useAppStore((s) => ({
+    balance: s.balance,
+    setTransactions: s.setTransactions,
+    setBalance: s.setBalance,
+  }))
 
   const [to, setTo] = useState('')
   const [amount, setAmount] = useState('')
   const [memo, setMemo] = useState('')
   const [fee, setFee] = useState('0.001')
 
-  const handleSend = (e: FormEvent) => {
+  const handleSend = async (e: FormEvent) => {
     e.preventDefault()
     const amt = parseFloat(amount)
-    const feeValue = parseFloat(fee)
-    const available = utxos.reduce((s, u) => s + u.amount, 0)
-    if (!to || isNaN(amt) || amt <= 0 || amt + feeValue > available) {
+    if (!to || isNaN(amt) || amt <= 0 || amt > balance) {
       alert(t('invalidAmount'))
       return
     }
-    const txid = `${Date.now()}`
-    setTransactions([...transactions, txid])
-    setBalance(balance - amt - feeValue)
-    setTo('')
-    setAmount('')
-    setMemo('')
-    alert(t('sent'))
+    try {
+      const res = await fetch('/api/sendtoaddress', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([to, amt]),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      const txid = data.result
+      const txRes = await fetch('/api/listtransactions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '[]',
+      })
+      const txData = await txRes.json()
+      if (Array.isArray(txData.result))
+        setTransactions(txData.result.map((tx: any) => tx.txid))
+      const balRes = await fetch('/api/getbalance', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '[]',
+      })
+      const balData = await balRes.json()
+      if (typeof balData.result === 'number') setBalance(balData.result)
+      setTo('')
+      setAmount('')
+      setMemo('')
+      alert(t('sent'))
+      return txid
+    } catch (err) {
+      console.error('send failed', err)
+      alert('send failed')
+    }
   }
 
   return (

--- a/frontend/src/hooks/useMiner.ts
+++ b/frontend/src/hooks/useMiner.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 import { useAppStore } from '@/store'
 
 export function useMiner() {
@@ -11,41 +11,32 @@ export function useMiner() {
     }),
   )
 
-  useEffect(() => {
-    const ws = new WebSocket('ws://localhost:8080/miner')
-    ws.onmessage = (e) => {
-      try {
-        const data = JSON.parse(e.data)
-        if (data.isMining !== undefined) setIsMining(data.isMining)
-        if (data.hashrate !== undefined) setMinerHashrate(data.hashrate)
-      } catch (err) {
-        console.error('miner ws error', err)
-      }
-    }
-    return () => ws.close()
-  }, [setIsMining, setMinerHashrate])
-
   const start = useCallback(async () => {
     try {
-      await fetch('/api/miner/start', {
+      await fetch('/api/setgenerate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ mode }),
+        body: JSON.stringify([true, 1]),
       })
       setIsMining(true)
     } catch (err) {
       console.error('start mining failed', err)
     }
-  }, [mode, setIsMining])
+  }, [setIsMining])
 
   const stop = useCallback(async () => {
     try {
-      await fetch('/api/miner/stop', { method: 'POST' })
+      await fetch('/api/setgenerate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([false]),
+      })
       setIsMining(false)
+      setMinerHashrate(0)
     } catch (err) {
       console.error('stop mining failed', err)
     }
-  }, [setIsMining])
+  }, [setIsMining, setMinerHashrate])
 
   return { isMining, mode, start, stop }
 }

--- a/frontend/src/store/settings.ts
+++ b/frontend/src/store/settings.ts
@@ -11,10 +11,30 @@ export const createSettingsSlice: AppSlice<SettingsSlice> = (set) => ({
   setVerbosity: (verbosity) => set({ verbosity }),
   setZmqEndpoint: (zmqEndpoint) => set({ zmqEndpoint }),
   exportWallet: async () => {
-    console.log('export wallet')
+    try {
+      const res = await fetch('/api/exportwallet')
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'wallet.dat'
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      console.error('export wallet failed', err)
+    }
   },
   importWallet: async (file) => {
-    console.log('import wallet', file)
+    try {
+      const content = await file.text()
+      await fetch('/api/importwallet', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      })
+    } catch (err) {
+      console.error('import wallet failed', err)
+    }
   },
   toggleDarkMode: () => set((state) => ({ darkMode: !state.darkMode })),
 })

--- a/frontend/src/store/wallet.ts
+++ b/frontend/src/store/wallet.ts
@@ -27,7 +27,7 @@ export const useWalletStore = create<WalletState>()(
 export const createWalletSlice: AppSlice<WalletSlice> = (set) => ({
   balance: 0,
   transactions: [],
-  address: 'adonai1placeholder',
+  address: '',
   utxos: [],
   setBalance: (balance) => set({ balance }),
   setTransactions: (transactions) => set({ transactions }),


### PR DESCRIPTION
## Summary
- hook miner controls to setgenerate RPC and track state
- wire wallet receive, send, history and settings to RPC calls
- replace dummy seed generator with BIP39 mnemonics

## Testing
- `npm test` (frontend)
- `npm test` (gateway)


------
https://chatgpt.com/codex/tasks/task_e_68b7ccfb9160832da9cad88491e02faa