### PR TITLE
fix: mark NavItem import as type

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@/lib/theme'
 import { useTranslation } from 'react-i18next'
-import Navigation, { NavItem } from './Navigation'
+import Navigation, { type NavItem } from './Navigation'
 
 export type Page = 'dashboard' | 'wallet' | 'mining' | 'network' | 'settings'
 


### PR DESCRIPTION
## Summary
- mark `NavItem` import as type-only in `Header` to prevent runtime module error

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: TS errors in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b2dee2a0832da460b6701d852a76