### PR TITLE
fix wallet store hook infinite loop

### DIFF
--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -1,17 +1,21 @@
 import { useCallback } from 'react'
 import { useAppStore } from '@/store'
+import { shallow } from 'zustand/shallow'
 
 const WALLET_NAME = 'adonai'
 
 export function useWallet() {
   const { setBalance, setTransactions, setAddress, setUtxos, csrfToken } =
-    useAppStore((s) => ({
-      setBalance: s.setBalance,
-      setTransactions: s.setTransactions,
-      setAddress: s.setAddress,
-      setUtxos: s.setUtxos,
-      csrfToken: s.csrfToken,
-    }))
+    useAppStore(
+      (s) => ({
+        setBalance: s.setBalance,
+        setTransactions: s.setTransactions,
+        setAddress: s.setAddress,
+        setUtxos: s.setUtxos,
+        csrfToken: s.csrfToken,
+      }),
+      shallow,
+    )
 
   const refresh = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- avoid infinite loop in wallet hook by comparing store snapshot with `shallow`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8b3f6066c832da7e73c954e5c7788