### PR TITLE
fix: prevent wallet hook infinite loop

### DIFF
--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -1,21 +1,14 @@
 import { useCallback } from 'react'
 import { useAppStore } from '@/store'
-import { shallow } from 'zustand/shallow'
 
 const WALLET_NAME = 'adonai'
 
 export function useWallet() {
-  const { setBalance, setTransactions, setAddress, setUtxos, csrfToken } =
-    useAppStore(
-      (s) => ({
-        setBalance: s.setBalance,
-        setTransactions: s.setTransactions,
-        setAddress: s.setAddress,
-        setUtxos: s.setUtxos,
-        csrfToken: s.csrfToken,
-      }),
-      shallow,
-    )
+  const setBalance = useAppStore((s) => s.setBalance)
+  const setTransactions = useAppStore((s) => s.setTransactions)
+  const setAddress = useAppStore((s) => s.setAddress)
+  const setUtxos = useAppStore((s) => s.setUtxos)
+  const csrfToken = useAppStore((s) => s.csrfToken)
 
   const refresh = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- avoid infinite loop in wallet hook by selecting store values individually instead of object

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8b5688b8c832dbe97e2acfde6b8bf