### PR TITLE
Disable nav tabs without wallet and remove pre-release banner

### DIFF
--- a/frontend/src/components/AdonaiWalletUI.tsx
+++ b/frontend/src/components/AdonaiWalletUI.tsx
@@ -7,7 +7,6 @@ import {
   Pickaxe,
   Wifi,
   ShieldCheck,
-  AlertTriangle,
   Play,
   Clock,
   Network,
@@ -112,16 +111,6 @@ export default function AdonaiWalletUI() {
             </button>
           ))}
         </nav>
-
-        {/* Warning */}
-        <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 p-3 text-amber-900 text-sm flex items-start gap-2">
-          <AlertTriangle className="h-4 w-4 mt-0.5" />
-          <p>
-            This is a{' '}
-            <span className="font-medium">pre-release test build</span> — use at
-            your own risk. Do not use for mining or merchant applications.
-          </p>
-        </div>
 
         {/* Content */}
         <main className="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -7,7 +7,6 @@ import {
   Pickaxe,
   Wifi,
   ShieldCheck,
-  AlertTriangle,
   Play,
   Clock,
   Network,
@@ -74,11 +73,15 @@ export default function Dashboard() {
             <button
               key={t.key}
               onClick={() => setActiveTab(t.key)}
+              disabled={!isWalletLoaded}
               className={[
-                'inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm',
-                activeTab === t.key
+                'inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed',
+                activeTab === t.key && isWalletLoaded
                   ? 'bg-white shadow-sm ring-1 ring-slate-200'
-                  : 'bg-slate-100 hover:bg-white hover:shadow-sm ring-1 ring-transparent hover:ring-slate-200',
+                  : 'bg-slate-100 ring-1 ring-transparent',
+                isWalletLoaded
+                  ? 'hover:bg-white hover:shadow-sm hover:ring-slate-200'
+                  : '',
               ].join(' ')}
             >
               {t.icon}
@@ -86,16 +89,6 @@ export default function Dashboard() {
             </button>
           ))}
         </nav>
-
-        {/* Warning */}
-        <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 p-3 text-amber-900 text-sm flex items-start gap-2">
-          <AlertTriangle className="h-4 w-4 mt-0.5" />
-          <p>
-            This is a{' '}
-            <span className="font-medium">pre-release test build</span> — use at
-            your own risk. Do not use for mining or merchant applications.
-          </p>
-        </div>
 
         {/* Content */}
         <main className="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/frontend/src/features/dashboard/Dashboard.tsx
+++ b/frontend/src/features/dashboard/Dashboard.tsx
@@ -113,13 +113,6 @@ export default function Dashboard() {
             />
           </div>
         </div>
-
-        {/* Warning banner */}
-        <div className="bg-[#fff5cc] text-[12px] text-neutral-900 px-3 py-2 border-y border-[#e7c74d]">
-          This is a pre-release test build - use at your own risk - do not use
-          for mining or merchant applications
-        </div>
-
         {/* Content */}
         <div className="p-3">
           {activeTab === 'overview' && (


### PR DESCRIPTION
## Summary
- Disable dashboard navigation tabs when no wallet is loaded
- Remove pre-release warning banners from dashboard components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbd40b2708832d96121f0457d52602