### PR TITLE
Document hybrid fee model and RPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,28 @@ La emisión de ADONAI sigue una política de halving similar a la de Bitcoin:
 - **Emisión primer año:** ~12,61 millones de ADO.
 - **Duración prevista:** ~124 años (31 reducciones).
 
-## 7. Parámetros del génesis
+## 7. Modelo de tarifas híbrido
+
+Adonai calcula las comisiones con una fórmula híbrida
+`fee = α·peso + β·valor` con límites mínimos y máximos.
+Los valores por defecto son:
+
+- α = `0.000001 ADO/kvB`
+- β = `0.0005%`
+- mínimo = `0.000001 ADO`
+- máximo = `0.01 ADO`
+
+Consulta los parámetros actuales con:
+
+```bash
+adonai-cli getfeemodel
+```
+
+En redes de prueba pueden modificarse en caliente con
+`adonai-cli setfeemodel`. Para más detalles consulta
+[`doc/feemodel.md`](doc/feemodel.md).
+
+## 8. Parámetros del génesis
 
 Consulta `GENESIS.adonai.txt` (inclúyelo en la raíz del repo).
 Contiene:
@@ -130,7 +151,7 @@ Contiene:
 
 ---
 
-## 8. Licencia
+## 9. Licencia
 
 Este repositorio se publica bajo **MIT**. Consulta el archivo [`LICENSE`](LICENSE) para los términos completos.  
 Mantén los avisos de copyright originales de Bitcoin Core al redistribuir.

--- a/doc/feemodel.md
+++ b/doc/feemodel.md
@@ -33,6 +33,20 @@ $ adonai-cli setfeemodel 0.000002 0.000007 0.000001 0.01
 Command line options `-feemodelalpha`, `-feemodelbeta`,
 `-feemodelmin` and `-feemodelmax` allow setting the values at startup.
 
+## Anti-spam protections
+
+- Outputs smaller than the dust threshold derived from `fee_min` are
+  rejected to prevent UTXO bloat.
+- Peers are rate-limited on transaction relay to reduce spam.
+- Consolidation transactions without fresh change outputs receive a
+  50% fee discount.
+
+## Security notes
+
+The block subsidy (one block every ~45 s) remains the main incentive
+for miners. Fees are a small complement. See
+[fee_security.md](fee_security.md) for monitoring guidance.
+
 ## Examples
 
 - Sending 1 ADO → fee ≈ `0.000006 ADO`.


### PR DESCRIPTION
## Summary
- Document hybrid weight/value fee algorithm and new getfeemodel/setfeemodel RPCs
- Explain anti-spam protections and security notes
- Include hybrid fee model overview in main README

## Testing
- `python3 test/lint/lint-files.py` *(fails: missing shebangs in existing test fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68bc43f2b0b4832daa0d553c112215e3