### PR TITLE
wallet: clarify error when fee below minimum

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1329,9 +1329,11 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     }
 
     // fee_needed should now always be less than or equal to the current fees that we pay.
-    // If it is not, it is a bug.
+    // If it is greater, the user-selected fee is insufficient.
     if (fee_needed > current_fee) {
-        return util::Error{Untranslated(STR_INTERNAL_BUG("Fee needed > fee paid"))};
+        return util::Error{strprintf(_("Fee too low (paid %s, required %s)"),
+                                     FormatMoney(current_fee),
+                                     FormatMoney(fee_needed))};
     }
 
     // Give up if change keypool ran out and change is required


### PR DESCRIPTION
## Summary
- show paid and required fees when the selected fee is too low

## Testing
- `test/lint/lint-spelling.py src/wallet/spend.cpp` *(fails: codespell not installed)*
- `test/lint/lint-files.py src/wallet/spend.cpp` *(fails: 152 lint errors in repo)*
- `cmake -B build` *(fails: missing Boost 1.73)*

------
https://chatgpt.com/codex/tasks/task_e_68bc63be06c8832d89faea460eaf7e6c