### PR TITLE
qt: add restore from seed dialog

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -162,6 +162,8 @@ if(ENABLE_WALLET)
       coincontroltreewidget.h
       createwalletdialog.cpp
       createwalletdialog.h
+      restoremnemonicdialog.cpp
+      restoremnemonicdialog.h
       editaddressdialog.cpp
       editaddressdialog.h
       openuridialog.cpp

--- a/src/qt/adonaigui.cpp
+++ b/src/qt/adonaigui.cpp
@@ -27,6 +27,7 @@
 #include <qt/walletframe.h>
 #include <qt/walletmodel.h>
 #include <qt/walletview.h>
+#include <qt/restoremnemonicdialog.h>
 #endif // ENABLE_WALLET
 
 #ifdef Q_OS_MACOS
@@ -38,6 +39,7 @@
 #include <common/system.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
+#include <util/memory.h>
 #include <node/interface_ui.h>
 #include <util/translation.h>
 #include <validation.h>
@@ -355,6 +357,10 @@ void BitcoinGUI::createActions()
     //: Status tip for Restore Wallet menu item
     m_restore_wallet_action->setStatusTip(tr("Restore a wallet from a backup file"));
 
+    m_restore_mnemonic_action = new QAction(tr("Restore from seed…"), this);
+    m_restore_mnemonic_action->setEnabled(false);
+    m_restore_mnemonic_action->setStatusTip(tr("Restore a wallet from a BIP39 seed phrase"));
+
     m_close_all_wallets_action = new QAction(tr("Close All Wallets…"), this);
     m_close_all_wallets_action->setStatusTip(tr("Close all wallets"));
 
@@ -454,6 +460,7 @@ void BitcoinGUI::createActions()
             auto backup_file_path = fs::PathFromString(backup_file.toStdString());
             activity->restore(backup_file_path, wallet_name.toStdString());
         });
+        connect(m_restore_mnemonic_action, &QAction::triggered, this, &BitcoinGUI::restoreFromMnemonic);
         connect(m_close_wallet_action, &QAction::triggered, [this] {
             m_wallet_controller->closeWallet(walletFrame->currentWalletModel(), this);
         });
@@ -512,6 +519,7 @@ void BitcoinGUI::createMenuBar()
         file->addSeparator();
         file->addAction(backupWalletAction);
         file->addAction(m_restore_wallet_action);
+        file->addAction(m_restore_mnemonic_action);
         file->addSeparator();
         file->addAction(openAction);
         file->addAction(signMessageAction);
@@ -718,6 +726,7 @@ void BitcoinGUI::setWalletController(WalletController* wallet_controller, bool s
     m_open_wallet_action->setEnabled(true);
     m_open_wallet_action->setMenu(m_open_wallet_menu);
     m_restore_wallet_action->setEnabled(true);
+    m_restore_mnemonic_action->setEnabled(true);
     m_migrate_wallet_action->setEnabled(true);
     m_migrate_wallet_action->setMenu(m_migrate_wallet_menu);
 
@@ -1224,6 +1233,29 @@ void BitcoinGUI::createWallet()
     connect(activity, &CreateWalletActivity::created, this, &BitcoinGUI::setCurrentWallet);
     connect(activity, &CreateWalletActivity::created, rpcConsole, &RPCConsole::setCurrentWallet);
     activity->create();
+#endif // ENABLE_WALLET
+}
+
+void BitcoinGUI::restoreFromMnemonic()
+{
+#ifdef ENABLE_WALLET
+    RestoreMnemonicDialog dlg(this);
+    if (dlg.exec() != QDialog::Accepted) return;
+
+    std::string name = dlg.walletName().toStdString();
+    std::string mnemonic = dlg.mnemonic().toStdString();
+    std::string passphrase = dlg.passphrase().toStdString();
+    std::string derivation = dlg.derivationPath().toStdString();
+    int rescan = dlg.rescanHeight();
+    bool disable = dlg.disablePrivateKeys();
+
+    auto activity = new RestoreMnemonicActivity(getWalletController(), this);
+    connect(activity, &RestoreMnemonicActivity::restored, this, &BitcoinGUI::setCurrentWallet, Qt::QueuedConnection);
+    connect(activity, &RestoreMnemonicActivity::restored, rpcConsole, &RPCConsole::setCurrentWallet, Qt::QueuedConnection);
+    activity->restore(name, mnemonic, passphrase, derivation, rescan, disable);
+
+    memory_cleanse(mnemonic.data(), mnemonic.size());
+    memory_cleanse(passphrase.data(), passphrase.size());
 #endif // ENABLE_WALLET
 }
 

--- a/src/qt/adonaigui.h
+++ b/src/qt/adonaigui.h
@@ -157,6 +157,7 @@ private:
     QAction* m_open_wallet_action{nullptr};
     QMenu* m_open_wallet_menu{nullptr};
     QAction* m_restore_wallet_action{nullptr};
+    QAction* m_restore_mnemonic_action{nullptr};
     QAction* m_close_wallet_action{nullptr};
     QAction* m_close_all_wallets_action{nullptr};
     QAction* m_wallet_selector_label_action = nullptr;
@@ -231,6 +232,7 @@ public Q_SLOTS:
     void setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, SyncType synctype, SynchronizationState sync_state);
     /** Launch the wallet creation modal (no-op if wallet is not compiled) **/
     void createWallet();
+    void restoreFromMnemonic();
 
     /** Notify the user of an event from the core network or transaction handling code.
        @param[in] title             the message box / notification title

--- a/src/qt/forms/restoremnemonicdialog.ui
+++ b/src/qt/forms/restoremnemonicdialog.ui
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>RestoreMnemonicDialog</class>
+ <widget class="QDialog" name="RestoreMnemonicDialog">
+  <property name="windowTitle">
+   <string>Restore from seed</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_wallet_name">
+       <property name="text"><string>Wallet name</string></property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="wallet_name_edit"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_mnemonic">
+       <property name="text"><string>Mnemonic</string></property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QPlainTextEdit" name="mnemonic_edit">
+       <property name="minimumHeight"><number>80</number></property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_passphrase">
+       <property name="text"><string>Passphrase</string></property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="passphrase_edit">
+       <property name="echoMode"><enum>QLineEdit::Password</enum></property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_preset">
+       <property name="text"><string>Derivation preset</string></property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="preset_combo"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_derivation">
+       <property name="text"><string>Derivation path</string></property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLineEdit" name="derivation_edit"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_rescan">
+       <property name="text"><string>Rescan height</string></property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QSpinBox" name="rescan_spinbox">
+       <property name="minimum"><number>0</number></property>
+       <property name="maximum"><number>2100000000</number></property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_watchonly">
+       <property name="text"><string>Watch-only</string></property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QCheckBox" name="watchonly_checkbox">
+       <property name="text"><string>Disable private keys</string></property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons"><set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set></property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/restoremnemonicdialog.cpp
+++ b/src/qt/restoremnemonicdialog.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 The Adonai Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bitcoin-build-config.h> // IWYU pragma: keep
+
+#include <qt/restoremnemonicdialog.h>
+#include <qt/forms/ui_restoremnemonicdialog.h>
+#include <qt/guiutil.h>
+
+#include <wallet/bip39.h>
+#include <wallet/wordlist_en.h>
+#include <util/memory.h>
+
+#include <QPushButton>
+
+RestoreMnemonicDialog::RestoreMnemonicDialog(QWidget* parent) :
+    QDialog(parent, GUIUtil::dialog_flags),
+    ui(new Ui::RestoreMnemonicDialog)
+{
+    ui->setupUi(this);
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Restore"));
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+
+    ui->preset_combo->addItem(tr("Segwit bech32 (BIP84)"));
+    ui->preset_combo->addItem(tr("Taproot (BIP86)"));
+    ui->preset_combo->setItemData(1, 0, Qt::UserRole - 1);
+    ui->preset_combo->addItem(tr("Custom…"));
+
+    ui->derivation_edit->setText("m/84'/5353'/0'");
+    ui->derivation_edit->setVisible(false);
+
+    connect(ui->preset_combo, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index){
+        ui->derivation_edit->setVisible(index == 2);
+        if (index == 0) ui->derivation_edit->setText("m/84'/5353'/0'");
+        if (index == 1) ui->derivation_edit->setText("m/86'/5353'/0'");
+    });
+
+    connect(ui->wallet_name_edit, &QLineEdit::textChanged, this, &RestoreMnemonicDialog::updateOkButton);
+    connect(ui->mnemonic_edit, &QPlainTextEdit::textChanged, this, &RestoreMnemonicDialog::updateOkButton);
+}
+
+RestoreMnemonicDialog::~RestoreMnemonicDialog()
+{
+    delete ui;
+}
+
+void RestoreMnemonicDialog::updateOkButton()
+{
+    std::vector<std::string> wordlist(std::begin(BIP39_WORDLIST_EN), std::end(BIP39_WORDLIST_EN));
+    std::string text = ui->mnemonic_edit->toPlainText().toStdString();
+    bool valid = BIP39_ValidateMnemonic(text, wordlist);
+    memory_cleanse(text.data(), text.size());
+    bool enable = valid && !ui->wallet_name_edit->text().isEmpty();
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(enable);
+}
+
+QString RestoreMnemonicDialog::walletName() const
+{
+    return ui->wallet_name_edit->text();
+}
+
+QString RestoreMnemonicDialog::mnemonic() const
+{
+    return ui->mnemonic_edit->toPlainText();
+}
+
+QString RestoreMnemonicDialog::passphrase() const
+{
+    return ui->passphrase_edit->text();
+}
+
+QString RestoreMnemonicDialog::derivationPath() const
+{
+    return ui->derivation_edit->text();
+}
+
+int RestoreMnemonicDialog::rescanHeight() const
+{
+    return ui->rescan_spinbox->value();
+}
+
+bool RestoreMnemonicDialog::disablePrivateKeys() const
+{
+    return ui->watchonly_checkbox->isChecked();
+}

--- a/src/qt/restoremnemonicdialog.h
+++ b/src/qt/restoremnemonicdialog.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 The Adonai Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_RESTOREMNEMONICDIALOG_H
+#define BITCOIN_QT_RESTOREMNEMONICDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class RestoreMnemonicDialog;
+}
+
+class RestoreMnemonicDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit RestoreMnemonicDialog(QWidget* parent = nullptr);
+    ~RestoreMnemonicDialog();
+
+    QString walletName() const;
+    QString mnemonic() const;
+    QString passphrase() const;
+    QString derivationPath() const;
+    int rescanHeight() const;
+    bool disablePrivateKeys() const;
+
+private:
+    Ui::RestoreMnemonicDialog* ui;
+    void updateOkButton();
+};
+
+#endif // BITCOIN_QT_RESTOREMNEMONICDIALOG_H

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -15,10 +15,18 @@
 #include <external_signer.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
+#include <interfaces/chain.h>
 #include <util/string.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
 #include <wallet/wallet.h>
+#include <wallet/walletutil.h>
+#include <wallet/bip39.h>
+#include <wallet/bip32.h>
+#include <wallet/wordlist_en.h>
+#include <util/memory.h>
+#include <key_io.h>
+#include <outputtype.h>
 
 #include <algorithm>
 #include <chrono>
@@ -436,6 +444,103 @@ void RestoreWalletActivity::finish()
     }
 
     if (m_wallet_model) Q_EMIT restored(m_wallet_model);
+
+    Q_EMIT finished();
+}
+
+RestoreMnemonicActivity::RestoreMnemonicActivity(WalletController* wallet_controller, QWidget* parent_widget)
+    : WalletControllerActivity(wallet_controller, parent_widget)
+{
+}
+
+void RestoreMnemonicActivity::restore(const std::string& name,
+                                      const std::string& mnemonic,
+                                      const std::string& passphrase,
+                                      const std::string& derivation,
+                                      int rescan_height,
+                                      bool disable_private_keys)
+{
+    QString qname = QString::fromStdString(name);
+    showProgressDialog(
+        tr("Restore from seed"),
+        tr("Restoring Wallet <b>%1</b>…").arg(qname.toHtmlEscaped()));
+
+    QTimer::singleShot(0, worker(), [this, name, mnemonic, passphrase, derivation, rescan_height, disable_private_keys] {
+        WalletContext& context = *node().walletLoader().context();
+        std::vector<std::string> wordlist(std::begin(BIP39_WORDLIST_EN), std::end(BIP39_WORDLIST_EN));
+        std::string mnemonic_copy = mnemonic;
+        if (!BIP39_ValidateMnemonic(mnemonic_copy, wordlist)) {
+            memory_cleanse(mnemonic_copy.data(), mnemonic_copy.size());
+            m_error_message = Untranslated("Invalid mnemonic");
+            QTimer::singleShot(0, this, &RestoreMnemonicActivity::finish);
+            return;
+        }
+        std::vector<uint8_t> seed = BIP39_MnemonicToSeed(mnemonic_copy, passphrase);
+        memory_cleanse(mnemonic_copy.data(), mnemonic_copy.size());
+        BIP32Root root = BIP32_FromSeed(seed);
+        memory_cleanse(seed.data(), seed.size());
+        m_fingerprint = QString::fromStdString(strprintf("%08x", root.fingerprint));
+
+        WalletCreationStatus status;
+        std::shared_ptr<CWallet> wallet = CreateWalletFromMnemonic(*context.chain, name, mnemonic, passphrase, derivation, /*blank=*/false, disable_private_keys, true, &status);
+        memory_cleanse(const_cast<char*>(mnemonic.data()), mnemonic.size());
+        memory_cleanse(const_cast<char*>(passphrase.data()), passphrase.size());
+        if (!wallet || status != WalletCreationStatus::SUCCESS) {
+            m_error_message = Untranslated("Wallet creation failed");
+        } else {
+            wallet::AddWallet(context, wallet);
+            auto handle = wallet::MakeWallet(context, wallet);
+            wallet->BlockUntilSyncedToCurrentChain();
+            if (rescan_height >= 0) {
+                WalletRescanReserver reserver(*wallet);
+                if (!reserver.reserve(false)) {
+                    m_error_message = Untranslated("Wallet is currently rescanning");
+                } else {
+                    uint256 start_block;
+                    int tip_height = wallet->GetLastBlockHeight();
+                    if (rescan_height > tip_height || !wallet->chain().findAncestorByHeight(wallet->GetLastBlockHash(), rescan_height, FoundBlock().hash(start_block))) {
+                        m_error_message = Untranslated("Failed to determine rescan start block");
+                    } else {
+                        CWallet::ScanResult result = wallet->ScanForWalletTransactions(start_block, rescan_height, std::nullopt, reserver, /*fUpdate=*/true, /*save_progress=*/false);
+                        if (result.status != CWallet::ScanResult::SUCCESS) {
+                            m_error_message = Untranslated("Rescan failed");
+                        }
+                    }
+                }
+            }
+            if (m_error_message.empty()) {
+                m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(handle));
+            }
+        }
+
+        QTimer::singleShot(0, this, &RestoreMnemonicActivity::finish);
+    });
+}
+
+void RestoreMnemonicActivity::finish()
+{
+    if (!m_error_message.empty()) {
+        QMessageBox::critical(m_parent_widget, tr("Restore wallet failed"), QString::fromStdString(m_error_message.translated));
+    } else if (m_wallet_model) {
+        QStringList addresses;
+        if (auto dest1 = m_wallet_model->wallet().getNewDestination(OutputType::BECH32, "")) {
+            addresses << QString::fromStdString(EncodeDestination(*dest1));
+        }
+        if (auto dest2 = m_wallet_model->wallet().getNewDestination(OutputType::BECH32, "")) {
+            addresses << QString::fromStdString(EncodeDestination(*dest2));
+        }
+        if (auto change = m_wallet_model->wallet().getNewChangeDestination(OutputType::BECH32)) {
+            addresses << QString::fromStdString(EncodeDestination(*change));
+        }
+        m_addresses = addresses;
+        QString info = tr("Fingerprint: %1\n%2\n%3\n%4")
+                            .arg(m_fingerprint,
+                                 addresses.value(0),
+                                 addresses.value(1),
+                                 addresses.value(2));
+        QMessageBox::information(m_parent_widget, tr("Restore wallet message"), info);
+        Q_EMIT restored(m_wallet_model);
+    }
 
     Q_EMIT finished();
 }

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -22,6 +22,7 @@
 #include <QThread>
 #include <QTimer>
 #include <QString>
+#include <QStringList>
 
 class ClientModel;
 class OptionsModel;
@@ -178,6 +179,29 @@ Q_SIGNALS:
     void restored(WalletModel* wallet_model);
 
 private:
+    void finish();
+};
+
+class RestoreMnemonicActivity : public WalletControllerActivity
+{
+    Q_OBJECT
+
+public:
+    RestoreMnemonicActivity(WalletController* wallet_controller, QWidget* parent_widget);
+
+    void restore(const std::string& name,
+                 const std::string& mnemonic,
+                 const std::string& passphrase,
+                 const std::string& derivation,
+                 int rescan_height,
+                 bool disable_private_keys);
+
+Q_SIGNALS:
+    void restored(WalletModel* wallet_model);
+
+private:
+    QString m_fingerprint;
+    QStringList m_addresses;
     void finish();
 };
 


### PR DESCRIPTION
## Summary
- add `RestoreMnemonicDialog` for BIP39 seed entry
- wire GUI menu action to restore wallet via `RestoreMnemonicActivity`
- support mnemonic-based wallet creation with rescan and address preview

## Testing
- `cmake -S . -B build`
- `cmake --build build --target adonai-qt` *(fails: No rule to make target 'adonai-qt')*


------
https://chatgpt.com/codex/tasks/task_e_68bd3f9319f0832daca64286b0ccdcf8