### PR TITLE
qt: show rescan progress when restoring from seed and add descriptor export/import

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -88,6 +88,8 @@ The Bitcoin repo's [root README](/README.md) contains relevant information on th
 - [Tor Support](tor.md)
 - [Transaction Relay Policy](policy/README.md)
 - [ZMQ](zmq.md)
+- [Restoring a Wallet from a Seed](recover-from-seed.md)
+- [Exporting and Importing Wallet Descriptors](export-descriptors.md)
 
 License
 ---------------------

--- a/doc/export-descriptors.md
+++ b/doc/export-descriptors.md
@@ -1,0 +1,23 @@
+# Exporting and Importing Wallet Descriptors
+
+Descriptors describe the keys and scripts used by a wallet. Adonai can export and import these descriptors for backup or migration.
+
+## Export from the GUI
+
+1. Open the wallet and choose **File -> Export Descriptors…**.
+2. Pick a destination file. A JSON document with the wallet's active descriptors is written. If the wallet holds private keys, the file will contain the corresponding extended private keys, so store it securely.
+
+## Import in the GUI
+
+1. Choose **File -> Import Descriptors…**.
+2. Select a JSON file containing an array of descriptors as produced by the export step or by the `listdescriptors` RPC.
+3. The wallet will report whether each descriptor was imported successfully and rescan the blockchain if needed to discover existing transactions.
+
+## Command Line
+
+Use RPC calls:
+
+- Export: `bitcoin-cli -rpcwallet=<name> listdescriptors true > descriptors.json`
+- Import: `bitcoin-cli -rpcwallet=<name> importdescriptors "$(cat descriptors.json)"`
+
+These commands allow moving descriptor-based wallets between nodes or creating backups without exposing private keys if `listdescriptors` is called without the `true` argument.

--- a/doc/recover-from-seed.md
+++ b/doc/recover-from-seed.md
@@ -1,0 +1,23 @@
+# Restoring a Wallet from a Seed
+
+Adonai wallets can be recreated from a BIP39 mnemonic seed without storing the mnemonic on disk. The GUI and RPC interfaces allow reconstructing descriptor wallets from these phrases. Restored wallets use the derivation path `m/84'/5353'/0'` and a default gap limit of 20 addresses.
+
+## GUI
+
+1. Choose **File -> Restore from seed…**.
+2. Enter your 12- or 24-word seed. Optionally, provide the BIP39 passphrase.
+3. Select the derivation preset or enter a custom derivation path.
+4. (Recommended) Enable blockchain rescan and choose the block height to start from. If you skip this step, funds sent to the wallet before restoration may be missing and you will be prompted to confirm continuing without a rescan.
+5. Click **Restore** and monitor the progress dialog as blocks are scanned until the rescan completes.
+
+The mnemonic and derived seed are wiped from memory once the wallet is created.
+
+## RPC
+
+Use the `createwalletfrommnemonic` RPC:
+
+```
+createwalletfrommnemonic "wallet_name" "mnemonic" "passphrase" "m/84'/5353'/0'" rescan_height
+```
+
+The call returns the wallet fingerprint and preview addresses. The mnemonic is never written to disk.

--- a/src/qt/adonaigui.cpp
+++ b/src/qt/adonaigui.cpp
@@ -314,6 +314,10 @@ void BitcoinGUI::createActions()
     encryptWalletAction->setCheckable(true);
     backupWalletAction = new QAction(tr("&Backup Wallet…"), this);
     backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
+    m_export_descriptors_action = new QAction(tr("Export &Descriptors…"), this);
+    m_export_descriptors_action->setStatusTip(tr("Dump wallet descriptors to a file"));
+    m_import_descriptors_action = new QAction(tr("&Import Descriptors…"), this);
+    m_import_descriptors_action->setStatusTip(tr("Import wallet descriptors from a file"));
     changePassphraseAction = new QAction(tr("&Change Passphrase…"), this);
     changePassphraseAction->setStatusTip(tr("Change the passphrase used for wallet encryption"));
     signMessageAction = new QAction(tr("Sign &message…"), this);
@@ -392,6 +396,8 @@ void BitcoinGUI::createActions()
     {
         connect(encryptWalletAction, &QAction::triggered, walletFrame, &WalletFrame::encryptWallet);
         connect(backupWalletAction, &QAction::triggered, walletFrame, &WalletFrame::backupWallet);
+        connect(m_export_descriptors_action, &QAction::triggered, walletFrame, &WalletFrame::exportDescriptors);
+        connect(m_import_descriptors_action, &QAction::triggered, walletFrame, &WalletFrame::importDescriptors);
         connect(changePassphraseAction, &QAction::triggered, walletFrame, &WalletFrame::changePassphrase);
         connect(signMessageAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
         connect(signMessageAction, &QAction::triggered, [this]{ gotoSignMessageTab(); });
@@ -518,6 +524,8 @@ void BitcoinGUI::createMenuBar()
         file->addAction(m_migrate_wallet_action);
         file->addSeparator();
         file->addAction(backupWalletAction);
+        file->addAction(m_export_descriptors_action);
+        file->addAction(m_import_descriptors_action);
         file->addAction(m_restore_wallet_action);
         file->addAction(m_restore_mnemonic_action);
         file->addSeparator();
@@ -834,6 +842,8 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     historyAction->setEnabled(enabled);
     encryptWalletAction->setEnabled(enabled);
     backupWalletAction->setEnabled(enabled);
+    m_export_descriptors_action->setEnabled(enabled);
+    m_import_descriptors_action->setEnabled(enabled);
     changePassphraseAction->setEnabled(enabled);
     signMessageAction->setEnabled(enabled);
     verifyMessageAction->setEnabled(enabled);
@@ -1247,6 +1257,16 @@ void BitcoinGUI::restoreFromMnemonic()
     std::string passphrase = dlg.passphrase().toStdString();
     std::string derivation = dlg.derivationPath().toStdString();
     int rescan = dlg.rescanHeight();
+    if (rescan < 0) {
+        auto ret = QMessageBox::warning(this, tr("Rescan disabled"),
+            tr("Without rescanning, funds sent to this wallet before restoration may be missing. Continue?"),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        if (ret != QMessageBox::Yes) {
+            memory_cleanse(mnemonic.data(), mnemonic.size());
+            memory_cleanse(passphrase.data(), passphrase.size());
+            return;
+        }
+    }
     bool disable = dlg.disablePrivateKeys();
 
     auto activity = new RestoreMnemonicActivity(getWalletController(), this);

--- a/src/qt/adonaigui.h
+++ b/src/qt/adonaigui.h
@@ -149,6 +149,8 @@ private:
     QAction* encryptWalletAction = nullptr;
     QAction* backupWalletAction = nullptr;
     QAction* changePassphraseAction = nullptr;
+    QAction* m_export_descriptors_action{nullptr};
+    QAction* m_import_descriptors_action{nullptr};
     QAction* aboutQtAction = nullptr;
     QAction* openRPCConsoleAction = nullptr;
     QAction* openAction = nullptr;

--- a/src/qt/forms/restoremnemonicdialog.ui
+++ b/src/qt/forms/restoremnemonicdialog.ui
@@ -52,23 +52,32 @@
      <item row="4" column="1">
       <widget class="QLineEdit" name="derivation_edit"/>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_rescan">
-       <property name="text"><string>Rescan height</string></property>
+    <item row="5" column="0">
+      <widget class="QCheckBox" name="rescan_checkbox">
+       <property name="text"><string>Rescan blockchain</string></property>
       </widget>
      </item>
      <item row="5" column="1">
+      <widget class="QLabel" name="label_dummy"/>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_rescan_height">
+       <property name="text"><string>Rescan height</string></property>
+      </widget>
+     </item>
+     <item row="6" column="1">
       <widget class="QSpinBox" name="rescan_spinbox">
+       <property name="enabled"><bool>false</bool></property>
        <property name="minimum"><number>0</number></property>
        <property name="maximum"><number>2100000000</number></property>
       </widget>
      </item>
-     <item row="6" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="label_watchonly">
        <property name="text"><string>Watch-only</string></property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="7" column="1">
       <widget class="QCheckBox" name="watchonly_checkbox">
        <property name="text"><string>Disable private keys</string></property>
       </widget>

--- a/src/qt/restoremnemonicdialog.cpp
+++ b/src/qt/restoremnemonicdialog.cpp
@@ -13,6 +13,9 @@
 #include <util/memory.h>
 
 #include <QPushButton>
+#include <QKeyEvent>
+#include <QMessageBox>
+#include <QCheckBox>
 
 RestoreMnemonicDialog::RestoreMnemonicDialog(QWidget* parent) :
     QDialog(parent, GUIUtil::dialog_flags),
@@ -30,6 +33,15 @@ RestoreMnemonicDialog::RestoreMnemonicDialog(QWidget* parent) :
     ui->derivation_edit->setText("m/84'/5353'/0'");
     ui->derivation_edit->setVisible(false);
 
+    ui->rescan_checkbox->setChecked(false);
+    ui->label_rescan_height->setEnabled(false);
+    ui->rescan_spinbox->setEnabled(false);
+
+    connect(ui->rescan_checkbox, &QCheckBox::toggled, this, [this](bool checked) {
+        ui->label_rescan_height->setEnabled(checked);
+        ui->rescan_spinbox->setEnabled(checked);
+    });
+
     connect(ui->preset_combo, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index){
         ui->derivation_edit->setVisible(index == 2);
         if (index == 0) ui->derivation_edit->setText("m/84'/5353'/0'");
@@ -38,6 +50,9 @@ RestoreMnemonicDialog::RestoreMnemonicDialog(QWidget* parent) :
 
     connect(ui->wallet_name_edit, &QLineEdit::textChanged, this, &RestoreMnemonicDialog::updateOkButton);
     connect(ui->mnemonic_edit, &QPlainTextEdit::textChanged, this, &RestoreMnemonicDialog::updateOkButton);
+
+    ui->mnemonic_edit->setContextMenuPolicy(Qt::NoContextMenu);
+    ui->mnemonic_edit->installEventFilter(this);
 }
 
 RestoreMnemonicDialog::~RestoreMnemonicDialog()
@@ -77,10 +92,22 @@ QString RestoreMnemonicDialog::derivationPath() const
 
 int RestoreMnemonicDialog::rescanHeight() const
 {
-    return ui->rescan_spinbox->value();
+    return ui->rescan_checkbox->isChecked() ? ui->rescan_spinbox->value() : -1;
 }
 
 bool RestoreMnemonicDialog::disablePrivateKeys() const
 {
     return ui->watchonly_checkbox->isChecked();
+}
+
+bool RestoreMnemonicDialog::eventFilter(QObject* obj, QEvent* event)
+{
+    if (obj == ui->mnemonic_edit && event->type() == QEvent::KeyPress) {
+        QKeyEvent* key = static_cast<QKeyEvent*>(event);
+        if (key->matches(QKeySequence::Copy) || key->matches(QKeySequence::Cut)) {
+            QMessageBox::warning(this, tr("Security warning"), tr("Copying the seed to the clipboard is disabled."));
+            return true;
+        }
+    }
+    return QDialog::eventFilter(obj, event);
 }

--- a/src/qt/restoremnemonicdialog.h
+++ b/src/qt/restoremnemonicdialog.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_RESTOREMNEMONICDIALOG_H
 
 #include <QDialog>
+#include <QEvent>
 
 namespace Ui {
 class RestoreMnemonicDialog;
@@ -25,6 +26,9 @@ public:
     QString derivationPath() const;
     int rescanHeight() const;
     bool disablePrivateKeys() const;
+
+protected:
+    bool eventFilter(QObject* obj, QEvent* event) override;
 
 private:
     Ui::RestoreMnemonicDialog* ui;

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -30,11 +30,13 @@
 
 #include <algorithm>
 #include <chrono>
+#include <boost/signals2/connection.hpp>
 
 #include <QApplication>
 #include <QMessageBox>
 #include <QMetaObject>
 #include <QMutexLocker>
+#include <QString>
 #include <QThread>
 #include <QTimer>
 #include <QWindow>
@@ -206,21 +208,22 @@ WalletControllerActivity::WalletControllerActivity(WalletController* wallet_cont
 
 void WalletControllerActivity::showProgressDialog(const QString& title_text, const QString& label_text, bool show_minimized)
 {
-    auto progress_dialog = new QProgressDialog(m_parent_widget);
-    progress_dialog->setAttribute(Qt::WA_DeleteOnClose);
-    connect(this, &WalletControllerActivity::finished, progress_dialog, &QWidget::close);
+    m_progress_dialog = new QProgressDialog(m_parent_widget);
+    m_progress_dialog->setAttribute(Qt::WA_DeleteOnClose);
+    connect(this, &WalletControllerActivity::finished, m_progress_dialog, &QWidget::close);
+    connect(m_progress_dialog, &QObject::destroyed, [this] { m_progress_dialog = nullptr; });
 
-    progress_dialog->setWindowTitle(title_text);
-    progress_dialog->setLabelText(label_text);
-    progress_dialog->setRange(0, 0);
-    progress_dialog->setCancelButton(nullptr);
-    progress_dialog->setWindowModality(Qt::ApplicationModal);
-    GUIUtil::PolishProgressDialog(progress_dialog);
+    m_progress_dialog->setWindowTitle(title_text);
+    m_progress_dialog->setLabelText(label_text);
+    m_progress_dialog->setRange(0, 100);
+    m_progress_dialog->setCancelButton(nullptr);
+    m_progress_dialog->setWindowModality(Qt::ApplicationModal);
+    GUIUtil::PolishProgressDialog(m_progress_dialog);
     // The setValue call forces QProgressDialog to start the internal duration estimation.
     // See details in https://bugreports.qt.io/browse/QTBUG-47042.
-    progress_dialog->setValue(0);
+    m_progress_dialog->setValue(0);
     // When requested, launch dialog minimized
-    if (show_minimized) progress_dialog->showMinimized();
+    if (show_minimized) m_progress_dialog->showMinimized();
 }
 
 CreateWalletActivity::CreateWalletActivity(WalletController* wallet_controller, QWidget* parent_widget)
@@ -501,6 +504,17 @@ void RestoreMnemonicActivity::restore(const std::string& name,
                     if (rescan_height > tip_height || !wallet->chain().findAncestorByHeight(wallet->GetLastBlockHash(), rescan_height, FoundBlock().hash(start_block))) {
                         m_error_message = Untranslated("Failed to determine rescan start block");
                     } else {
+                        boost::signals2::scoped_connection handler;
+                        if (m_progress_dialog) {
+                            handler = wallet->ShowProgress.connect([this](const std::string& title, int progress) {
+                                QMetaObject::invokeMethod(m_progress_dialog, [this, title, progress] {
+                                    if (m_progress_dialog) {
+                                        m_progress_dialog->setLabelText(QString::fromStdString(title));
+                                        m_progress_dialog->setValue(progress);
+                                    }
+                                }, Qt::QueuedConnection);
+                            });
+                        }
                         CWallet::ScanResult result = wallet->ScanForWalletTransactions(start_block, rescan_height, std::nullopt, reserver, /*fUpdate=*/true, /*save_progress=*/false);
                         if (result.status != CWallet::ScanResult::SUCCESS) {
                             m_error_message = Untranslated("Rescan failed");

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -112,6 +112,7 @@ protected:
     WalletController* const m_wallet_controller;
     QWidget* const m_parent_widget;
     WalletModel* m_wallet_model{nullptr};
+    QProgressDialog* m_progress_dialog{nullptr};
     bilingual_str m_error_message;
     std::vector<bilingual_str> m_warning_message;
 };

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -250,6 +250,18 @@ void WalletFrame::backupWallet()
         walletView->backupWallet();
 }
 
+void WalletFrame::exportDescriptors()
+{
+    WalletView* walletView = currentWalletView();
+    if (walletView) walletView->exportDescriptors();
+}
+
+void WalletFrame::importDescriptors()
+{
+    WalletView* walletView = currentWalletView();
+    if (walletView) walletView->importDescriptors();
+}
+
 void WalletFrame::changePassphrase()
 {
     WalletView *walletView = currentWalletView();

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -89,6 +89,10 @@ public Q_SLOTS:
     void encryptWallet();
     /** Backup the wallet */
     void backupWallet();
+    /** Export wallet descriptors */
+    void exportDescriptors();
+    /** Import wallet descriptors */
+    void importDescriptors();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -25,10 +25,14 @@
 
 #include <QAction>
 #include <QFileDialog>
+#include <QFile>
+#include <QTextStream>
+#include <QUrl>
 #include <QHBoxLayout>
 #include <QProgressDialog>
 #include <QPushButton>
 #include <QVBoxLayout>
+#include <univalue.h>
 
 WalletView::WalletView(WalletModel* wallet_model, const PlatformStyle* _platformStyle, QWidget* parent)
     : QStackedWidget(parent),
@@ -226,6 +230,96 @@ void WalletView::backupWallet()
     else {
         Q_EMIT message(tr("Backup Successful"), tr("The wallet data was successfully saved to %1.").arg(filename),
             CClientUIInterface::MSG_INFORMATION);
+    }
+}
+
+void WalletView::exportDescriptors()
+{
+    QString filename = GUIUtil::getSaveFileName(this,
+        tr("Export Wallet Descriptors"), QString(),
+        tr("JSON Files") + QLatin1String(" (*.json)"), nullptr);
+    if (filename.isEmpty()) return;
+
+    UniValue params(UniValue::VARR);
+    params.push_back(true);
+    QByteArray encoded = QUrl::toPercentEncoding(walletModel->getWalletName());
+    std::string uri = "/wallet/" + std::string(encoded.constData(), encoded.length());
+    UniValue result;
+    try {
+        result = walletModel->node().executeRpc("listdescriptors", params, uri);
+    } catch (UniValue& objError) {
+        try {
+            int code = objError["code"].getInt<int>();
+            std::string msg = objError["message"].get_str();
+            Q_EMIT message(tr("Export Failed"), QString::fromStdString(msg) + " (code " + QString::number(code) + ")", CClientUIInterface::MSG_ERROR);
+        } catch (const std::exception&) {
+            Q_EMIT message(tr("Export Failed"), QString::fromStdString(objError.write()), CClientUIInterface::MSG_ERROR);
+        }
+        return;
+    } catch (const std::exception& e) {
+        Q_EMIT message(tr("Export Failed"), tr("Error: %1").arg(QString::fromStdString(e.what())), CClientUIInterface::MSG_ERROR);
+        return;
+    }
+
+    QFile file(filename);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        Q_EMIT message(tr("Export Failed"), tr("Could not open %1 for writing").arg(filename), CClientUIInterface::MSG_ERROR);
+        return;
+    }
+    QTextStream out(&file);
+    out << QString::fromStdString(result.write(2));
+    file.close();
+    Q_EMIT message(tr("Export Successful"), tr("Wallet descriptors were saved to %1.").arg(filename), CClientUIInterface::MSG_INFORMATION);
+}
+
+void WalletView::importDescriptors()
+{
+    QString filename = GUIUtil::getOpenFileName(this,
+        tr("Import Wallet Descriptors"), QString(),
+        tr("JSON Files") + QLatin1String(" (*.json)"), nullptr);
+    if (filename.isEmpty()) return;
+
+    QFile file(filename);
+    if (!file.open(QIODevice::ReadOnly)) {
+        Q_EMIT message(tr("Import Failed"), tr("Could not open %1 for reading").arg(filename), CClientUIInterface::MSG_ERROR);
+        return;
+    }
+    QByteArray data = file.readAll();
+    file.close();
+
+    UniValue descs = UniValue::read(std::string(data.constData(), data.size()));
+    if (!descs.isArray()) {
+        Q_EMIT message(tr("Import Failed"), tr("File did not contain a descriptor array"), CClientUIInterface::MSG_ERROR);
+        return;
+    }
+    UniValue params(UniValue::VARR);
+    params.push_back(descs);
+    QByteArray encoded = QUrl::toPercentEncoding(walletModel->getWalletName());
+    std::string uri = "/wallet/" + std::string(encoded.constData(), encoded.length());
+    try {
+        UniValue res = walletModel->node().executeRpc("importdescriptors", params, uri);
+        bool ok = true;
+        for (const UniValue& r : res.get_array().getValues()) {
+            if (!r["success"].isBool() || !r["success"].get_bool()) {
+                ok = false;
+                break;
+            }
+        }
+        if (ok) {
+            Q_EMIT message(tr("Import Successful"), tr("Wallet descriptors were imported from %1.").arg(filename), CClientUIInterface::MSG_INFORMATION);
+        } else {
+            Q_EMIT message(tr("Import Failed"), tr("Some descriptors could not be imported"), CClientUIInterface::MSG_ERROR);
+        }
+    } catch (UniValue& objError) {
+        try {
+            int code = objError["code"].getInt<int>();
+            std::string msg = objError["message"].get_str();
+            Q_EMIT message(tr("Import Failed"), QString::fromStdString(msg) + " (code " + QString::number(code) + ")", CClientUIInterface::MSG_ERROR);
+        } catch (const std::exception&) {
+            Q_EMIT message(tr("Import Failed"), QString::fromStdString(objError.write()), CClientUIInterface::MSG_ERROR);
+        }
+    } catch (const std::exception& e) {
+        Q_EMIT message(tr("Import Failed"), tr("Error: %1").arg(QString::fromStdString(e.what())), CClientUIInterface::MSG_ERROR);
     }
 }
 

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -95,6 +95,10 @@ public Q_SLOTS:
     void encryptWallet();
     /** Backup the wallet */
     void backupWallet();
+    /** Export wallet descriptors */
+    void exportDescriptors();
+    /** Import wallet descriptors */
+    void importDescriptors();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */

--- a/src/wallet/bip32.cpp
+++ b/src/wallet/bip32.cpp
@@ -16,6 +16,7 @@ BIP32Root BIP32_FromSeed(const std::vector<uint8_t>& seed)
     std::copy(ext.chaincode.begin(), ext.chaincode.end(), root.chain_code.begin());
     CKeyID id = root.master_key.GetPubKey().GetID();
     root.fingerprint = ReadBE32(id.begin());
+    memory_cleanse(&ext, sizeof(ext));
     return root;
 }
 
@@ -51,9 +52,11 @@ bool BIP32_Derive(const BIP32Root& root, const std::string& path, CKey& out_priv
         CExtKey derived;
         if (!ext.Derive(derived, index)) {
             memory_cleanse(&derived, sizeof(derived));
+            memory_cleanse(&ext, sizeof(ext));
             return false;
         }
         ext = derived;
+        memory_cleanse(&derived, sizeof(derived));
         pos = (next == std::string::npos) ? path.size() : next;
     }
     out_priv = ext.key;

--- a/src/wallet/bip39.cpp
+++ b/src/wallet/bip39.cpp
@@ -53,12 +53,19 @@ bool BIP39_ValidateMnemonic(const std::string& mnemonic, const std::vector<std::
         words.push_back(word);
     }
     const size_t words_len = words.size();
-    if (words_len % 3 != 0 || words_len < 12 || words_len > 24) return false;
+    if (words_len % 3 != 0 || words_len < 12 || words_len > 24) {
+        for (auto& w : words) memory_cleanse(w.data(), w.size());
+        return false;
+    }
     std::vector<int> indices;
     indices.reserve(words_len);
     for (const auto& w : words) {
         auto it = std::find(wordlist.begin(), wordlist.end(), w);
-        if (it == wordlist.end()) return false;
+        if (it == wordlist.end()) {
+            for (auto& ww : words) memory_cleanse(ww.data(), ww.size());
+            memory_cleanse(indices.data(), indices.size() * sizeof(int));
+            return false;
+        }
         indices.push_back(it - wordlist.begin());
     }
     std::vector<uint8_t> bits(words_len * 11);
@@ -79,10 +86,18 @@ bool BIP39_ValidateMnemonic(const std::string& mnemonic, const std::vector<std::
         uint8_t bit = (hash[i / 8] >> (7 - (i % 8))) & 1;
         if (bits[entropy_bits + i] != bit) {
             memory_cleanse(entropy.data(), entropy.size());
+            memory_cleanse(hash, sizeof(hash));
+            for (auto& ww : words) memory_cleanse(ww.data(), ww.size());
+            memory_cleanse(indices.data(), indices.size() * sizeof(int));
+            memory_cleanse(bits.data(), bits.size());
             return false;
         }
     }
     memory_cleanse(entropy.data(), entropy.size());
+    memory_cleanse(hash, sizeof(hash));
+    for (auto& ww : words) memory_cleanse(ww.data(), ww.size());
+    memory_cleanse(indices.data(), indices.size() * sizeof(int));
+    memory_cleanse(bits.data(), bits.size());
     return true;
 }
 
@@ -90,10 +105,13 @@ std::vector<uint8_t> BIP39_MnemonicToSeed(const std::string& mnemonic, const std
 {
     std::string salt = std::string("mnemonic") + passphrase;
     std::vector<uint8_t> salt_bytes(salt.begin(), salt.end());
+    std::vector<uint8_t> mnemonic_bytes(mnemonic.begin(), mnemonic.end());
     std::vector<uint8_t> seed(64);
-    PBKDF2_HMAC_SHA512((const unsigned char*)mnemonic.data(), mnemonic.size(),
+    PBKDF2_HMAC_SHA512(mnemonic_bytes.data(), mnemonic_bytes.size(),
                        salt_bytes.data(), salt_bytes.size(), 2048,
                        seed.data(), seed.size());
+    memory_cleanse(salt.data(), salt.size());
     memory_cleanse(salt_bytes.data(), salt_bytes.size());
+    memory_cleanse(mnemonic_bytes.data(), mnemonic_bytes.size());
     return seed;
 }

--- a/src/wallet/test/CMakeLists.txt
+++ b/src/wallet/test/CMakeLists.txt
@@ -24,5 +24,6 @@ target_sources(test_adonai
     wallet_transaction_tests.cpp
     walletdb_tests.cpp
     walletload_tests.cpp
+    mnemonic_tests.cpp
 )
 target_link_libraries(test_adonai adonai_wallet)

--- a/src/wallet/test/mnemonic_tests.cpp
+++ b/src/wallet/test/mnemonic_tests.cpp
@@ -1,0 +1,88 @@
+#include <wallet/bip39.h>
+#include <wallet/bip32.h>
+#include <wallet/walletutil.h>
+#include <wallet/test/wallet_test_fixture.h>
+
+#include <key_io.h>
+#include <script/descriptor.h>
+#include <util/strencodings.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace wallet;
+
+BOOST_AUTO_TEST_SUITE(mnemonic_tests)
+
+BOOST_AUTO_TEST_CASE(bip39_vectors)
+{
+    const std::string mnemonic12 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    auto seed12 = BIP39_MnemonicToSeed(mnemonic12, "TREZOR");
+    BOOST_CHECK_EQUAL(HexStr(seed12), "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04");
+
+    const std::string mnemonic24 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+    auto seed24 = BIP39_MnemonicToSeed(mnemonic24, "TREZOR");
+    BOOST_CHECK_EQUAL(HexStr(seed24), "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8");
+}
+
+BOOST_AUTO_TEST_CASE(bip32_vectors)
+{
+    const std::string mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    auto seed = BIP39_MnemonicToSeed(mnemonic, "TREZOR");
+    BIP32Root root = BIP32_FromSeed(seed);
+
+    CExtKey ext;
+    ext.key = root.master_key;
+    std::copy(root.chain_code.begin(), root.chain_code.end(), ext.chaincode.begin());
+    ext.nDepth = 0;
+    ext.nChild = 0;
+    WriteBE32(ext.vchFingerprint, root.fingerprint);
+
+    BOOST_CHECK_EQUAL(EncodeExtKey(ext), "xprv9s21ZrQH143K3h3fDYiay8mocZ3afhfULfb5GX8kCBdno77K4HiA15Tg23wpbeF1pLfs1c5SPmYHrEpTuuRhxMwvKDwqdKiGJS9XFKzUsAF");
+    BOOST_CHECK_EQUAL(EncodeExtPubKey(ext.Neuter()), "xpub661MyMwAqRbcGB88KaFbLGiYAat55APKhtWg4uYMkXAmfuSTbq2QYsn9sKJCj1YqZPafsboef4h4YbXXhNhPwMbkHTpkf3zLhx7HvFw1NDy");
+    BOOST_CHECK_EQUAL(root.fingerprint, 0xb4e3f5edu);
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_checksums)
+{
+    const std::string mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    auto seed = BIP39_MnemonicToSeed(mnemonic, "TREZOR");
+    BIP32Root root = BIP32_FromSeed(seed);
+
+    CExtKey master;
+    master.key = root.master_key;
+    std::copy(root.chain_code.begin(), root.chain_code.end(), master.chaincode.begin());
+    master.nDepth = 0;
+    master.nChild = 0;
+    WriteBE32(master.vchFingerprint, root.fingerprint);
+    std::string key_str = EncodeExtKey(master);
+
+    std::string ext_desc = "wpkh(" + key_str + "/84h/5353h/0h/0/*)";
+    std::string int_desc = "wpkh(" + key_str + "/84h/5353h/0h/1/*)";
+    BOOST_CHECK_EQUAL(GetDescriptorChecksum(ext_desc), "ap4hn2df");
+    BOOST_CHECK_EQUAL(GetDescriptorChecksum(int_desc), "v4skwla3");
+}
+
+BOOST_FIXTURE_TEST_CASE(mnemonic_roundtrip, WalletTestingSetup)
+{
+    const std::string mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    auto w1 = CreateWalletFromMnemonic(*m_node.chain, "w1", mnemonic, "", "m/84'/5353'/0'", /*blank=*/false, /*disable_private_keys=*/false, /*descriptors=*/true);
+    BOOST_CHECK(w1);
+    auto addr_ext = w1->GetNewDestination(OutputType::BECH32, "");
+    BOOST_CHECK(addr_ext); 
+    std::string ext1 = EncodeDestination(*addr_ext);
+    auto addr_int = w1->GetNewChangeDestination(OutputType::BECH32);
+    BOOST_CHECK(addr_int);
+    std::string int1 = EncodeDestination(*addr_int);
+
+    auto w2 = CreateWalletFromMnemonic(*m_node.chain, "w2", mnemonic, "", "m/84'/5353'/0'", /*blank=*/false, /*disable_private_keys=*/false, /*descriptors=*/true);
+    BOOST_CHECK(w2);
+    auto addr_ext2 = w2->GetNewDestination(OutputType::BECH32, "");
+    BOOST_CHECK(addr_ext2);
+    auto addr_int2 = w2->GetNewChangeDestination(OutputType::BECH32);
+    BOOST_CHECK(addr_int2);
+
+    BOOST_CHECK_EQUAL(ext1, EncodeDestination(*addr_ext2));
+    BOOST_CHECK_EQUAL(int1, EncodeDestination(*addr_int2));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/wallet_restore_from_mnemonic.py
+++ b/test/functional/wallet_restore_from_mnemonic.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Adonai Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test restoring descriptor wallets from a BIP39 mnemonic."""
+
+from decimal import Decimal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+
+class WalletRestoreFromMnemonicTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        node.createwalletfrommnemonic("w1", MNEMONIC)
+        w1 = node.get_wallet_rpc("w1")
+        addr_ext = w1.getnewaddress()
+        addr_int = w1.getrawchangeaddress()
+        self.generate(node, 101, addr_ext)
+        assert_equal(w1.getbalance(), Decimal("50"))
+
+        node.createwalletfrommnemonic("w2", MNEMONIC, "", "m/84'/5353'/0'", 0, False)
+        w2 = node.get_wallet_rpc("w2")
+        assert_equal(w2.getnewaddress(), addr_ext)
+        assert_equal(w2.getrawchangeaddress(), addr_int)
+        assert_equal(w2.getbalance(), w1.getbalance())
+
+
+if __name__ == '__main__':
+    WalletRestoreFromMnemonicTest().main()


### PR DESCRIPTION
## Summary
- track progress in WalletControllerActivity dialogs
- update mnemonic restore to report rescan progress
- add descriptor import/export actions in the GUI
- document seed restoration and descriptor export workflows
- warn when restoring from seed without rescanning

## Testing
- `cmake -S . -B build_dev_mode` *(fails: Could not find a package configuration file provided by "Boost")*
- `cmake --build build_dev_mode -j2` *(fails: No rule to make target 'Makefile')*
- `test/functional/test_runner.py wallet_restore_from_mnemonic.py` *(fails: No such file or directory: '/workspace/ADONAI/test/functional/../config.ini')*


------
https://chatgpt.com/codex/tasks/task_e_68bd4b1e570c832d8cfd2317801246f2