### PR TITLE
fix(rpc-client): replace non-existent getunconfirmedbalance, fix type mismatches

### DIFF
--- a/web/apps/frontend/src/lib/wallet-core.ts
+++ b/web/apps/frontend/src/lib/wallet-core.ts
@@ -75,7 +75,7 @@ async function deriveKey(password: string, salt: Uint8Array): Promise<CryptoKey>
     ['deriveKey']
   );
   return crypto.subtle.deriveKey(
-    { name: 'PBKDF2', salt, iterations: 250_000, hash: 'SHA-256' },
+    { name: 'PBKDF2', salt: salt as unknown as BufferSource, iterations: 250_000, hash: 'SHA-256' },
     keyMaterial,
     { name: 'AES-GCM', length: 256 },
     false,

--- a/web/packages/rpc-client/src/client.ts
+++ b/web/packages/rpc-client/src/client.ts
@@ -130,8 +130,16 @@ export class AdonaiRpcClient {
     return this.call('getbalance', ['*', minConfirmations]);
   }
 
+  getBalances(): Promise<{
+    mine: { trusted: number; untrusted_pending: number; immature: number };
+  }> {
+    return this.call('getbalances');
+  }
+
   getUnconfirmedBalance(): Promise<number> {
-    return this.call('getunconfirmedbalance');
+    return this.getBalances().then(
+      (b) => b.mine.untrusted_pending + b.mine.immature
+    );
   }
 
   getNewAddress(label = '', addressType = 'bech32'): Promise<string> {

--- a/web/packages/rpc-client/src/types.ts
+++ b/web/packages/rpc-client/src/types.ts
@@ -38,7 +38,7 @@ export interface BlockchainInfo {
   verificationprogress: number;
   chainwork: string;
   pruned: boolean;
-  warnings: string;
+  warnings: string | string[];
 }
 
 export interface Block {
@@ -119,9 +119,6 @@ export interface WalletInfo {
   walletname: string;
   walletversion: number;
   format: string;
-  balance: number;
-  unconfirmed_balance: number;
-  immature_balance: number;
   txcount: number;
   keypoolsize: number;
   keypoolsize_hd_internal: number;
@@ -133,6 +130,8 @@ export interface WalletInfo {
   scanning: boolean | { duration: number; progress: number };
   descriptors: boolean;
   external_signer: boolean;
+  blank?: boolean;
+  birthtime?: number;
 }
 
 export interface WalletTransaction {
@@ -200,13 +199,16 @@ export interface UnspentOutput {
 
 export interface MiningInfo {
   blocks: number;
-  currentblockweight: number;
-  currentblocktx: number;
+  currentblockweight?: number;
+  currentblocktx?: number;
+  bits?: string;
+  target?: string;
   difficulty: number;
   networkhashps: number;
   pooledtx: number;
   chain: string;
-  warnings: string;
+  next?: { height: number; bits: string; difficulty: number; target: string };
+  warnings: string | string[];
 }
 
 // ─── Network Types ────────────────────────────────────────────────────────────
@@ -225,7 +227,7 @@ export interface NetworkInfo {
   connections_out: number;
   relayfee: number;
   incrementalfee: number;
-  warnings: string;
+  warnings: string | string[];
 }
 
 export interface PeerInfo {
@@ -248,13 +250,12 @@ export interface PeerInfo {
 export interface FeeModel {
   alpha: number;
   beta: number;
-  minFee: number;
-  maxFee: number;
-  consolidationDiscount: number;
+  min: number;
+  max: number;
 }
 
 export interface FeeEstimate {
-  feerate: number;
+  feerate?: number;
   errors?: string[];
   blocks: number;
 }


### PR DESCRIPTION
## Summary

- Replace `getunconfirmedbalance` (not implemented in adonaid) with `getbalances`, computing unconfirmed as `untrusted_pending + immature`
- Fix `WalletInfo` type: remove `balance`/`unconfirmed_balance`/`immature_balance` fields absent from actual `getwalletinfo` response
- Fix `warnings` fields: now `string | string[]` (node returns arrays)
- Fix `MiningInfo`: optional `currentblockweight`/`currentblocktx`, add `bits`/`target`/`next` fields
- Fix `FeeModel`: rename `minFee`/`maxFee`/`consolidationDiscount` → `min`/`max` to match actual `getfeemodel` response
- Fix `FeeEstimate`: `feerate` is optional (absent when insufficient data)
- Fix TS2769 in `wallet-core.ts`: cast `Uint8Array` salt to `BufferSource`

## Test plan
- [x] `GET /api/v1/wallet/wallet1/info` → 200 with balance and unconfirmed
- [x] `POST /api/v1/wallet/wallet1/address` → returns new address
- [x] `GET /api/v1/wallet/wallet1/transactions` → returns tx list
- [x] `GET /api/v1/wallet/wallet1/mining-rewards` → returns reward list
- [x] `GET /api/v1/wallet/fee-estimate` → returns model and estimate
- [x] `npx tsc --noEmit` in both api and frontend → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)